### PR TITLE
Changes for unstructured grids

### DIFF
--- a/calcrs.F90
+++ b/calcrs.F90
@@ -1,10 +1,10 @@
 ! Include shortname defintions, so that the F77 code does not have to be modified to
 ! reference the CARMA structure.
 #include "carma_globaer.h"
-  
+
 
 !!-----------------------------------------------------------------------
-!! 
+!!
 !! Purpose: Calculating the surface resistance, using the PBL parameter.
 !!
 !! Method: Zhang(2001), Atmospheric Environment
@@ -32,65 +32,65 @@ subroutine calcrs(carma, cstate, ustar, tmp, radi, cc, vfall, rs, landidx, rc)
   real(kind=f), intent(in)              :: ustar    !! friction velocity [cm/s]
   real(kind=f), intent(in)              :: tmp      !! temperature [K]
   real(kind=f), intent(in)              :: radi     !! radius of the constitutent [cm]
-  real(kind=f), intent(in)              :: cc       !! slip correction factor  
+  real(kind=f), intent(in)              :: cc       !! slip correction factor
   real(kind=f), intent(in)              :: vfall    !! gravitational settling velocity, [cm/s]
   real(kind=f), intent(out)             :: rs       !! surface resistance [s/cm]
   integer,      intent(in)              :: landidx  !! landscape index, 1=land, 2=ocean, 3=sea ice
   integer, intent(inout)                :: rc       !! return code, negative indicates failure
-  
-  
+
+
 
 ! Local variables
   real(kind=f)            :: ebrn                   ! Brownian diffusion collection efficiency
   real(kind=f)            :: eimp                   ! Impaction collection efficiency
-  real(kind=f)            :: eint                   ! Interception collection efficiency                 
+  real(kind=f)            :: eint                   ! Interception collection efficiency
   real(kind=f)            :: db                     ! Brownian diffusivity
   real(kind=f)            :: sc                     ! Schmidt number
-  real(kind=f)            :: st                     ! Stokes number 
-  real(kind=f)            :: rhoadry                ! dry air density [g/cm3] 
-  real(kind=f)            :: eta                    ! kinematic viscosity of air [cm2/s] 
-  real(kind=f), parameter :: xkar = 0.4_f           ! Von Karman's constant     
+  real(kind=f)            :: st                     ! Stokes number
+  real(kind=f)            :: rhoadry                ! dry air density [g/cm3]
+  real(kind=f)            :: eta                    ! kinematic viscosity of air [cm2/s]
+  real(kind=f), parameter :: xkar = 0.4_f           ! Von Karman's constant
   real(kind=f), parameter :: eps0 = 3._f            ! empirical constant for rs, 3.0 in [Zhang, 2001], 1.0 in [Seinfeld and Pandis]
 
   ! exponent in the eb dependence on sc, 2/3 in [Seinfeld and Pandis, 1998], 1/2 in [Lewis and Schwartz, 2004]
   real(kind=f)            :: lam
 
   integer                 :: ibot
-  
+
   if (igridv .eq. I_CART) then
     ibot = 1
   else
     ibot = NZ
-  end if   
-  
-  ! Unit conversion   
-  rhoadry = rhoa(ibot) / zmet(ibot) / xmet(ibot) / ymet(ibot)   ! [g/cm3] 
+  end if
+
+  ! Unit conversion
+  rhoadry = rhoa(ibot) / zmet(ibot)    ! [g/cm3]
   eta = rmu(ibot) / rhoadry                                     ! rmu, aerodynamic viscosity of air [g/cm/s]
 
   if (landidx .eq. 1)  then
     lam = 2._f / 3._f
   else
     lam = 1._f / 2._f
-  end if   
-   
+  end if
+
   ! Surface Resistance = Brownian + Impaction + Interception
-  
+
   ! ** Brownian diffusion
   db = BK  * tmp * cc / (6._f * PI * rmu(ibot)  * radi)   ! [cm2/s]
-    
+
   sc = eta / db    ! [-]
   ebrn = sc**(-lam)
- 
-  ! ** Impaction 
+
+  ! ** Impaction
   st = vfall * ustar**2 / (GRAV * eta)   ! [-]
-   
-  ! [Slinn, 1982]   
-  ! eimp = 10. ** (-3._f/st)     
+
+  ! [Slinn, 1982]
+  ! eimp = 10. ** (-3._f/st)
 
   ! [Peters and Eiden, 1992]
   eimp = (st / (0.8_f + st))**2
 !  eimp = max(eimp, 1.e-10_f)
-  
+
   ! ** Interception
   !
   ! NOTE: Interception is not currently considered for ocean and ice.
@@ -100,12 +100,12 @@ subroutine calcrs(carma, cstate, ustar, tmp, radi, cc, vfall, rs, landidx, rc)
   else
     eint = 0._f
   end if
-  
-  if (ustar > 0._f) then       
+
+  if (ustar > 0._f) then
     rs = 1._f / (eps0 * ustar * (ebrn + eimp + eint ))   ! [s/cm]
   else
     rs = 0._f
   end if
-     
+
   return
 end subroutine calcrs

--- a/calcrs.F90
+++ b/calcrs.F90
@@ -65,7 +65,7 @@ subroutine calcrs(carma, cstate, ustar, tmp, radi, cc, vfall, rs, landidx, rc)
 
   ! Unit conversion
   rhoadry = rhoa(ibot) / zmet(ibot)    ! [g/cm3]
-  eta = rmu(ibot) / rhoadry                                     ! rmu, aerodynamic viscosity of air [g/cm/s]
+  eta = rmu(ibot) / rhoadry            ! rmu, aerodynamic viscosity of air [g/cm/s]
 
   if (landidx .eq. 1)  then
     lam = 2._f / 3._f

--- a/carma_globaer.h
+++ b/carma_globaer.h
@@ -43,15 +43,9 @@
 !  Gridding Information
 #define igridv        cstate%f_igridv
 #define igridh        cstate%f_igridh
-#define xmet          cstate%f_xmet
-#define ymet          cstate%f_ymet
 #define zmet          cstate%f_zmet
 #define zmetl         cstate%f_zmetl
-#define xc            cstate%f_xc
-#define yc            cstate%f_yc
 #define zc            cstate%f_zc
-#define dx            cstate%f_dx
-#define dy            cstate%f_dy
 #define dz            cstate%f_dz
 #define zl            cstate%f_zl
 #define lon           cstate%f_lon
@@ -95,7 +89,7 @@
 #define rmrat(igroup)           carma%f_group(igroup)%f_rmrat
 #define eshape(igroup)          carma%f_group(igroup)%f_eshape
 #define r(ibin,igroup)          carma%f_group(igroup)%f_r(ibin)
-#define rmass(ibin,igroup)      carma%f_group(igroup)%f_rmass(ibin) 
+#define rmass(ibin,igroup)      carma%f_group(igroup)%f_rmass(ibin)
 #define vol(ibin,igroup)        carma%f_group(igroup)%f_vol(ibin)
 #define dr(ibin,igroup)         carma%f_group(igroup)%f_dr(ibin)
 #define dm(ibin,igroup)         carma%f_group(igroup)%f_dm(ibin)
@@ -106,9 +100,9 @@
 #define rlow(ibin,igroup)       carma%f_group(igroup)%f_rlow(ibin)
 #define icorelem(icore,igroup)  carma%f_group(igroup)%f_icorelem(icore)
 #define ifallrtn(igroup)        carma%f_group(igroup)%f_ifallrtn
-#define arat(ibin,igroup)       carma%f_group(igroup)%f_arat(ibin) 
-#define rrat(ibin,igroup)       carma%f_group(igroup)%f_rrat(ibin) 
-#define rprat(ibin,igroup)      carma%f_group(igroup)%f_rprat(ibin) 
+#define arat(ibin,igroup)       carma%f_group(igroup)%f_arat(ibin)
+#define rrat(ibin,igroup)       carma%f_group(igroup)%f_rrat(ibin)
+#define rprat(ibin,igroup)      carma%f_group(igroup)%f_rprat(ibin)
 #define qext(iwave,ibin,igroup) carma%f_group(igroup)%f_qext(iwave,ibin)
 #define ssa(iwave,ibin,igroup)  carma%f_group(igroup)%f_ssa(iwave,ibin)
 #define do_mie(igroup)          carma%f_group(igroup)%f_do_mie
@@ -194,7 +188,7 @@
 #define nsubstep      cstate%f_nsubstep
 #define nretry        cstate%f_nretry
 #define zsubsteps     cstate%f_zsubsteps
-  
+
 !  Particle grid structure
 #define diffmass      carma%f_diffmass
 #define rhop          cstate%f_rhop

--- a/carma_globaer.h
+++ b/carma_globaer.h
@@ -45,11 +45,11 @@
 #define igridh        cstate%f_igridh
 #define zmet          cstate%f_zmet
 #define zmetl         cstate%f_zmetl
+#define xc            cstate%f_xc
+#define yc            cstate%f_yc
 #define zc            cstate%f_zc
 #define dz            cstate%f_dz
 #define zl            cstate%f_zl
-#define lon           cstate%f_lon
-#define lat           cstate%f_lat
 
 ! Element object
 #define elemname(ielem)       carma%f_element(ielem)%f_name

--- a/carma_types_mod.F90
+++ b/carma_types_mod.F90
@@ -400,9 +400,9 @@ module carma_types_mod
     logical                                       :: f_do_cnst_rlh
     logical, allocatable, dimension(:,:)          :: f_if_nuc       !(NELEM,NELEM)
     real(kind=f)                                  :: f_conmax
-    integer                                       :: f_igash2o = 0
-    integer                                       :: f_igash2so4 = 0
-    integer                                       :: f_igasso2 = 0
+    integer                                       :: f_igash2o
+    integer                                       :: f_igash2so4
+    integer                                       :: f_igasso2
     integer                                       :: f_maxsubsteps
     integer                                       :: f_minsubsteps
     integer                                       :: f_maxretries
@@ -580,6 +580,8 @@ module carma_types_mod
     !  igridv     flag to specify desired vertical grid coord system    {initatm}
     !  zmet       Vertical ds/dz (ds is metric distance)                {initatm}
     !  zmetl      Vertical ds/dz at edges (ds is metric distance)       {initatm}
+    !  xc         Horizontal position at center of box                  {initatm}
+    !  yc         Horizontal position at center of box                  {initatm}
     !  zc         Altitude at layer mid-point                           {initatm}
     !  dz         Thickness of vertical layers                          {initatm}
     !  zl         Altitude at top of layer                              {initatm}
@@ -589,11 +591,11 @@ module carma_types_mod
     integer :: f_igridv
     real(kind=f), allocatable, dimension(:)     :: f_zmet   ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_zmetl  ! (NZP1)
+    real(kind=f)                                :: f_xc
+    real(kind=f)                                :: f_yc
     real(kind=f), allocatable, dimension(:)     :: f_zc     ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_dz     ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_zl     ! (NZP1)
-    real(kind=f)                                :: f_lon
-    real(kind=f)                                :: f_lat
 
     ! Particle bin structure
     !

--- a/carma_types_mod.F90
+++ b/carma_types_mod.F90
@@ -400,9 +400,9 @@ module carma_types_mod
     logical                                       :: f_do_cnst_rlh
     logical, allocatable, dimension(:,:)          :: f_if_nuc       !(NELEM,NELEM)
     real(kind=f)                                  :: f_conmax
-    integer                                       :: f_igash2o
-    integer                                       :: f_igash2so4
-    integer                                       :: f_igasso2
+    integer                                       :: f_igash2o = 0
+    integer                                       :: f_igash2so4 = 0
+    integer                                       :: f_igasso2 = 0
     integer                                       :: f_maxsubsteps
     integer                                       :: f_minsubsteps
     integer                                       :: f_maxretries
@@ -578,32 +578,18 @@ module carma_types_mod
     ! Model Grid
     !
     !  igridv     flag to specify desired vertical grid coord system    {initatm}
-    !  igridh     flag to specify desired horizontal grid coord system  {initatm}
-    !  xmet       Horizontal ds/dx (ds is metric distance)              {initatm}
-    !  ymet       Horizontal ds/dy (ds is metric distance)              {initatm}
     !  zmet       Vertical ds/dz (ds is metric distance)                {initatm}
     !  zmetl      Vertical ds/dz at edges (ds is metric distance)       {initatm}
-    !  xc         Horizontal position at center of box                  {initatm}
-    !  yc         Horizontal position at center of box                  {initatm}
     !  zc         Altitude at layer mid-point                           {initatm}
-    !  dx         Horizontal grid spacing                               {initatm}
-    !  dy         Horizontal grid spacing                               {initatm}
     !  dz         Thickness of vertical layers                          {initatm}
     !  zl         Altitude at top of layer                              {initatm}
     !  lon        Longitude [deg] at xc, yc                             {initatm}
     !  lat        Latitude [deg] at xc, yc                              {initatm}
     !
     integer :: f_igridv
-    integer :: f_igridh
-    real(kind=f), allocatable, dimension(:)     :: f_xmet   ! (NZ)
-    real(kind=f), allocatable, dimension(:)     :: f_ymet   ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_zmet   ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_zmetl  ! (NZP1)
-    real(kind=f), allocatable, dimension(:)     :: f_xc     ! (NZ)
-    real(kind=f), allocatable, dimension(:)     :: f_yc     ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_zc     ! (NZ)
-    real(kind=f), allocatable, dimension(:)     :: f_dx     ! (NZ)
-    real(kind=f), allocatable, dimension(:)     :: f_dy     ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_dz     ! (NZ)
     real(kind=f), allocatable, dimension(:)     :: f_zl     ! (NZP1)
     real(kind=f)                                :: f_lon

--- a/carmastate_mod.F90
+++ b/carmastate_mod.F90
@@ -84,15 +84,15 @@ contains
   !! @see CARMA_Initialize
   !! @see CARMASTATE_Destroy
   subroutine CARMASTATE_Create(cstate, carma_ptr, time, dtime, NZ, igridv,   &
-      lat, lon, zc, zl, p, pl, t, rc, qh2o, relhum, told, radint)
+      xc, yc, zc, zl, p, pl, t, rc, qh2o, relhum, told, radint)
     type(carmastate_type), intent(inout)    :: cstate      !! the carma state object
     type(carma_type), pointer, intent(in)   :: carma_ptr   !! (in) the carma object
     real(kind=f), intent(in)                :: time        !! the model time [s]
     real(kind=f), intent(in)                :: dtime       !! the timestep size [s]
     integer, intent(in)                     :: NZ          !! the number of vertical grid points
     integer, intent(in)                     :: igridv      !! vertical grid type
-    real(kind=f), intent(in)                :: lat         !! latitude at center [degrees north]
-    real(kind=f), intent(in)                :: lon         !! longitude at center [degrees east]
+    real(kind=f), intent(in)                :: xc          !! x at center
+    real(kind=f), intent(in)                :: yc          !! y at center
     real(kind=f), intent(in)                :: zc(NZ)      !! z at center
     real(kind=f), intent(in)                :: zl(NZ+1)    !! z at edge
     real(kind=f), intent(in)                :: p(NZ)       !! pressure at center [Pa]
@@ -130,8 +130,8 @@ contains
     cstate%f_igridv = igridv
 
     ! Store away the grid location information.
-    cstate%f_lat  = lat
-    cstate%f_lon  = lon
+    cstate%f_yc  = yc
+    cstate%f_xc  = yc
 
     ! Allocate all the dynamic variables related to state.
     call CARMASTATE_Allocate(cstate, rc)
@@ -240,15 +240,15 @@ contains
   !! @see CARMA_Initialize
   !! @see CARMASTATE_Destroy
   subroutine CARMASTATE_CreateFromReference(cstate, carma_ptr, time, dtime, NZ, igridv, &
-      lat, lon, zc, zl, p, pl, t, rc, qh2o, relhum, qh2so4)
+      xc, yc, zc, zl, p, pl, t, rc, qh2o, relhum, qh2so4)
     type(carmastate_type), intent(inout)    :: cstate      !! the carma state object
     type(carma_type), pointer, intent(in)   :: carma_ptr   !! (in) the carma object
     real(kind=f), intent(in)                :: time        !! the model time [s]
     real(kind=f), intent(in)                :: dtime       !! the timestep size [s]
     integer, intent(in)                     :: NZ          !! the number of vertical grid points
     integer, intent(in)                     :: igridv      !! vertical grid type
-    real(kind=f), intent(in)                :: lat         !! latitude at center [degrees north]
-    real(kind=f), intent(in)                :: lon         !! longitude at center [degrees east]
+    real(kind=f), intent(in)                :: xc          !! x at center
+    real(kind=f), intent(in)                :: yc          !! y at center
     real(kind=f), intent(in)                :: zc(NZ)      !! z at center
     real(kind=f), intent(in)                :: zl(NZ+1)    !! z at edge
     real(kind=f), intent(in)                :: p(NZ)       !! pressure at center [Pa]
@@ -286,8 +286,8 @@ contains
     cstate%f_igridv = igridv
 
     ! Store away the grid location information.
-    cstate%f_lat  = lat
-    cstate%f_lon  = lon
+    cstate%f_xc  = xc
+    cstate%f_yc  = yc
 
     ! Allocate all the dynamic variables related to state.
     call CARMASTATE_Allocate(cstate, rc)
@@ -1026,7 +1026,7 @@ contains
   !! @see CARMA_GetGas
   !! @see CARMA_Step
   !! @see CARMASTATE_SetGas
-  subroutine CARMASTATE_Get(cstate, rc, max_nsubstep, max_nretry, nstep, nsubstep, nretry, zsubsteps, lat, lon)
+  subroutine CARMASTATE_Get(cstate, rc, max_nsubstep, max_nretry, nstep, nsubstep, nretry, zsubsteps, xc, yc)
     type(carmastate_type), intent(in)     :: cstate            !! the carma state object
     integer, intent(out)                  :: rc                !! return code, negative indicates failure
     integer, optional, intent(out)        :: max_nsubstep      !! maximum number of substeps in a step
@@ -1035,8 +1035,8 @@ contains
     integer, optional, intent(out)        :: nsubstep          !! total number of substeps taken
     real(kind=f), optional, intent(out)   :: nretry            !! total number of retries taken
     real(kind=f), optional, intent(out)   :: zsubsteps(cstate%f_NZ) !! number of substeps taken per vertical grid point
-    real(kind=f), optional, intent(out)   :: lat               !! grid center latitude [deg]
-    real(kind=f), optional, intent(out)   :: lon               !! grid center longitude [deg]
+    real(kind=f), optional, intent(out)   :: xc                !! x location at center
+    real(kind=f), optional, intent(out)   :: yc                !! y location at center
 
     ! Assume success.
     rc = RC_OK
@@ -1047,8 +1047,8 @@ contains
     if (present(nsubstep))     nsubstep     = cstate%f_nsubstep
     if (present(nretry))       nretry       = cstate%f_nretry
     if (present(zsubsteps))    zsubsteps    = cstate%f_zsubsteps
-    if (present(lat))          lat          = cstate%f_lat
-    if (present(lon))          lon          = cstate%f_lon
+    if (present(xc))           xc           = cstate%f_xc
+    if (present(yc))           yc           = cstate%f_yc
 
     return
   end subroutine CARMASTATE_Get

--- a/carmastate_mod.F90
+++ b/carmastate_mod.F90
@@ -65,10 +65,6 @@ contains
   !! MKS units which are more commonly used in parent models. The units and grid
   !! orientation depend on the grid type:
   !!
-  !!  - igridh
-  !!    - I_CART   : Cartesian coordinates, units in [m]
-  !!    - I_LL     : Lat/Lon coordinates, units in [degrees]
-  !!
   !!  - igridv
   !!    - I_CART   : Cartesian coordinates, units in [m], bottom at NZ=1
   !!    - I_SIG    : Sigma coordinates, unitless [P/P0], top at NZ=1
@@ -87,21 +83,16 @@ contains
   !! @see CARMA_Create
   !! @see CARMA_Initialize
   !! @see CARMASTATE_Destroy
-  subroutine CARMASTATE_Create(cstate, carma_ptr, time, dtime, NZ, igridv, igridh,  &
-      lat, lon, xc, dx, yc, dy, zc, zl, p, pl, t, rc, qh2o, relhum, told, radint)
+  subroutine CARMASTATE_Create(cstate, carma_ptr, time, dtime, NZ, igridv,   &
+      lat, lon, zc, zl, p, pl, t, rc, qh2o, relhum, told, radint)
     type(carmastate_type), intent(inout)    :: cstate      !! the carma state object
     type(carma_type), pointer, intent(in)   :: carma_ptr   !! (in) the carma object
     real(kind=f), intent(in)                :: time        !! the model time [s]
     real(kind=f), intent(in)                :: dtime       !! the timestep size [s]
     integer, intent(in)                     :: NZ          !! the number of vertical grid points
     integer, intent(in)                     :: igridv      !! vertical grid type
-    integer, intent(in)                     :: igridh      !! horizontal grid type
     real(kind=f), intent(in)                :: lat         !! latitude at center [degrees north]
     real(kind=f), intent(in)                :: lon         !! longitude at center [degrees east]
-    real(kind=f), intent(in)                :: xc(NZ)      !! x at center
-    real(kind=f), intent(in)                :: dx(NZ)      !! ix width
-    real(kind=f), intent(in)                :: yc(NZ)      !! y at center
-    real(kind=f), intent(in)                :: dy(NZ)      !! y width
     real(kind=f), intent(in)                :: zc(NZ)      !! z at center
     real(kind=f), intent(in)                :: zl(NZ+1)    !! z at edge
     real(kind=f), intent(in)                :: p(NZ)       !! pressure at center [Pa]
@@ -137,7 +128,6 @@ contains
 
     ! Save the grid definition.
     cstate%f_igridv = igridv
-    cstate%f_igridh = igridh
 
     ! Store away the grid location information.
     cstate%f_lat  = lat
@@ -147,10 +137,6 @@ contains
     call CARMASTATE_Allocate(cstate, rc)
     if (rc < 0) return
 
-    cstate%f_xc(:)  = xc(:)
-    cstate%f_dx(:)  = dx(:)
-    cstate%f_yc(:)  = yc(:)
-    cstate%f_dy(:)  = dy(:)
     cstate%f_zc(:)  = zc(:)
     cstate%f_zl(:)  = zl(:)
 
@@ -175,13 +161,6 @@ contains
     ! Calculate the metrics, ...
     ! if Cartesian coordinates were specifed, then the units need to be converted
     ! from MKS to CGS.
-    if (cstate%f_igridh == I_CART) then
-      cstate%f_xc = cstate%f_xc * RM2CGS
-      cstate%f_dx = cstate%f_dx * RM2CGS
-      cstate%f_yc = cstate%f_yc * RM2CGS
-      cstate%f_dy = cstate%f_dy * RM2CGS
-    end if
-
     if (cstate%f_igridv == I_CART) then
       cstate%f_zc = cstate%f_zc * RM2CGS
       cstate%f_zl = cstate%f_zl * RM2CGS
@@ -205,7 +184,7 @@ contains
         call vaporp_h2o_murphy2005(carma_ptr, cstate, iz, rc, pvap_liq, pvap_ice)
         if (rc < 0) return
 
-        gc_cgs = qh2o(iz)*cstate%f_rhoa_wet(iz) / (cstate%f_zmet(iz)*cstate%f_xmet(iz)*cstate%f_ymet(iz))
+        gc_cgs = qh2o(iz)*cstate%f_rhoa_wet(iz) / cstate%f_zmet(iz)
         cstate%f_relhum(iz) = ( gc_cgs * rvap * t(iz)) / pvap_liq
       enddo
     end if
@@ -260,21 +239,16 @@ contains
   !! @see CARMA_Create
   !! @see CARMA_Initialize
   !! @see CARMASTATE_Destroy
-  subroutine CARMASTATE_CreateFromReference(cstate, carma_ptr, time, dtime, NZ, igridv, igridh,  &
-      lat, lon, xc, dx, yc, dy, zc, zl, p, pl, t, rc, qh2o, relhum, qh2so4)
+  subroutine CARMASTATE_CreateFromReference(cstate, carma_ptr, time, dtime, NZ, igridv, &
+      lat, lon, zc, zl, p, pl, t, rc, qh2o, relhum, qh2so4)
     type(carmastate_type), intent(inout)    :: cstate      !! the carma state object
     type(carma_type), pointer, intent(in)   :: carma_ptr   !! (in) the carma object
     real(kind=f), intent(in)                :: time        !! the model time [s]
     real(kind=f), intent(in)                :: dtime       !! the timestep size [s]
     integer, intent(in)                     :: NZ          !! the number of vertical grid points
     integer, intent(in)                     :: igridv      !! vertical grid type
-    integer, intent(in)                     :: igridh      !! horizontal grid type
     real(kind=f), intent(in)                :: lat         !! latitude at center [degrees north]
     real(kind=f), intent(in)                :: lon         !! longitude at center [degrees east]
-    real(kind=f), intent(in)                :: xc(NZ)      !! x at center
-    real(kind=f), intent(in)                :: dx(NZ)      !! ix width
-    real(kind=f), intent(in)                :: yc(NZ)      !! y at center
-    real(kind=f), intent(in)                :: dy(NZ)      !! y width
     real(kind=f), intent(in)                :: zc(NZ)      !! z at center
     real(kind=f), intent(in)                :: zl(NZ+1)    !! z at edge
     real(kind=f), intent(in)                :: p(NZ)       !! pressure at center [Pa]
@@ -310,7 +284,6 @@ contains
 
     ! Save the grid definition.
     cstate%f_igridv = igridv
-    cstate%f_igridh = igridh
 
     ! Store away the grid location information.
     cstate%f_lat  = lat
@@ -320,10 +293,6 @@ contains
     call CARMASTATE_Allocate(cstate, rc)
     if (rc < 0) return
 
-    cstate%f_xc(:)  = xc(:)
-    cstate%f_dx(:)  = dx(:)
-    cstate%f_yc(:)  = yc(:)
-    cstate%f_dy(:)  = dy(:)
     cstate%f_zc(:)  = zc(:)
     cstate%f_zl(:)  = zl(:)
 
@@ -337,13 +306,6 @@ contains
     ! Calculate the metrics, ...
     ! if Cartesian coordinates were specifed, then the units need to be converted
     ! from MKS to CGS.
-    if (cstate%f_igridh == I_CART) then
-      cstate%f_xc = cstate%f_xc * RM2CGS
-      cstate%f_dx = cstate%f_dx * RM2CGS
-      cstate%f_yc = cstate%f_yc * RM2CGS
-      cstate%f_dy = cstate%f_dy * RM2CGS
-    end if
-
     if (cstate%f_igridv == I_CART) then
       cstate%f_zc = cstate%f_zc * RM2CGS
       cstate%f_zl = cstate%f_zl * RM2CGS
@@ -368,7 +330,7 @@ contains
           call vaporp_h2o_murphy2005(carma_ptr, cstate, iz, rc, pvap_liq, pvap_ice)
           if (rc < 0) return
 
-          gc_cgs = qh2o(iz) * cstate%f_rhoa_wet(iz) / (cstate%f_zmet(iz)*cstate%f_xmet(iz)*cstate%f_ymet(iz))
+          gc_cgs = qh2o(iz) * cstate%f_rhoa_wet(iz) / cstate%f_zmet(iz)
           cstate%f_relhum(iz) = (gc_cgs * rvap * t(iz)) / pvap_liq
         enddo
 
@@ -385,7 +347,7 @@ contains
 
           gc_cgs = (rvap * t(iz)) / (pvap_liq * relhum(iz))
           cstate%f_gc(iz, carma_ptr%f_igash2o) = gc_cgs * &
-               (cstate%f_zmet(iz)*cstate%f_xmet(iz)*cstate%f_ymet(iz)) / &
+               cstate%f_zmet(iz) / &
                cstate%f_rhoa_wet(iz)
         enddo
       end if
@@ -486,7 +448,7 @@ contains
     ! existing allocations.
 
     ! Allocate the variables needed for setupatm.
-    if (.not. (allocated(cstate%f_xmet))) then
+    if (.not. (allocated(cstate%f_zmet))) then
 
       NZ      = cstate%f_NZ
       NZP1    = cstate%f_NZP1
@@ -497,15 +459,9 @@ contains
       NWAVE   = cstate%f_carma%f_NWAVE
 
       allocate( &
-        cstate%f_xmet(NZ), &
-        cstate%f_ymet(NZ), &
         cstate%f_zmet(NZ), &
         cstate%f_zmetl(NZP1), &
-        cstate%f_xc(NZ), &
-        cstate%f_yc(NZ), &
         cstate%f_zc(NZ), &
-        cstate%f_dx(NZ), &
-        cstate%f_dy(NZ), &
         cstate%f_dz(NZ), &
         cstate%f_zl(NZP1), &
         cstate%f_pc(NZ,NBIN,NELEM), &
@@ -639,8 +595,8 @@ contains
           stat=ier)
         if (ier /= 0) then
           if (cstate%f_carma%f_do_print) then
-             write(cstate%f_carma%f_LUNOPRT, *) "CARMASTATE_Allocate::&
-                  ERROR allocating gas arrays, status=", ier
+             write(cstate%f_carma%f_LUNOPRT, *) "CARMASTATE_Allocate:: "&
+                  //"ERROR allocating gas arrays, status=", ier
           end if
           rc = RC_ERROR
           return
@@ -738,18 +694,12 @@ contains
     ! Check to see if the arrays are already allocated. If so, deallocate them.
 
     ! Allocate the variables needed for setupatm.
-    if (allocated(cstate%f_xmet)) then
+    if (allocated(cstate%f_zmet)) then
 
       deallocate( &
-        cstate%f_xmet, &
-        cstate%f_ymet, &
         cstate%f_zmet, &
         cstate%f_zmetl, &
-        cstate%f_xc, &
-        cstate%f_yc, &
         cstate%f_zc, &
-        cstate%f_dx, &
-        cstate%f_dy, &
         cstate%f_dz, &
         cstate%f_zl, &
         cstate%f_pc, &
@@ -944,11 +894,6 @@ contains
 
     integer                               :: iz     ! vertical index
     integer                               :: igas   ! gas index
-    integer                               :: ielem
-    integer                               :: ibin
-    integer                               :: igroup
-    logical                               :: swelling   ! Do any groups undergo partcile swelling?
-    integer                               :: i1, i2, j1, j2
 
     ! Assume success.
     rc = RC_OK
@@ -1225,8 +1170,7 @@ contains
     ! If this is the partcile # element, then determine some other statistics.
     if (ienconc == ielem) then
       if (present(nmr))           nmr(:)             = (cstate%f_pc(:, ibin, ielem) / cstate%f_rhoa_wet(:)) * 1000._f
-      if (present(numberDensity)) numberDensity(:)   = cstate%f_pc(:, ibin, ielem) / &
-           (cstate%f_xmet(:)*cstate%f_ymet(:)*cstate%f_zmet(:))
+      if (present(numberDensity)) numberDensity(:)   = cstate%f_pc(:, ibin, ielem) / cstate%f_zmet(:)
       if (present(r_wet))         r_wet(:)           = cstate%f_r_wet(:, ibin, igroup)
       if (present(rhop_wet))      rhop_wet(:)        = cstate%f_rhop_wet(:, ibin, igroup)
       if (present(rhop_dry))      rhop_dry(:)        = cstate%f_rhop(:, ibin, igroup)
@@ -1251,7 +1195,7 @@ contains
 
       if (cstate%f_carma%f_do_grow) then
         if (present(nucleationRate)) nucleationRate(:) = cstate%f_pc_nucl(:, ibin, ielem) / &
-             (cstate%f_xmet(:)*cstate%f_ymet(:)*cstate%f_zmet(:)) / cstate%f_dtime
+                                                         cstate%f_zmet(:) / cstate%f_dtime
       else
         if (present(nucleationRate)) nucleationRate(:) = CAM_FILL
       end if
@@ -1341,8 +1285,7 @@ contains
     ienconc = cstate%f_carma%f_group(igroup)%f_ienconc
     if (ienconc == ielem) then
       if (present(nmr))           nmr(:)             = (cstate%f_pcd(:, ibin, ielem) / cstate%f_rhoa_wet(:)) * 1000._f
-      if (present(numberDensity)) numberDensity(:)   = cstate%f_pcd(:, ibin, ielem) / &
-           (cstate%f_xmet(:)*cstate%f_ymet(:)*cstate%f_zmet(:))
+      if (present(numberDensity)) numberDensity(:)   = cstate%f_pcd(:, ibin, ielem) / cstate%f_zmet(:)
       if (present(r_wet))         r_wet(:)           = cstate%f_r_wet(:, ibin, igroup)
       if (present(rhop_wet))      rhop_wet(:)        = cstate%f_rhop_wet(:, ibin, igroup)
     else
@@ -1424,8 +1367,7 @@ contains
     if (present(p))         p(:) = cstate%f_p(:) / RPA2CGS
 
     ! Convert rhoa from the scaled units to mks.
-    if (present(rhoa_wet))  rhoa_wet(:) = (cstate%f_rhoa_wet(:) / &
-         (cstate%f_zmet(:)*cstate%f_xmet(:)*cstate%f_ymet(:))) * 1e6_f / 1e3_f
+    if (present(rhoa_wet))  rhoa_wet(:) = (cstate%f_rhoa_wet(:) / cstate%f_zmet(:)) * 1e6_f / 1e3_f
 
     if (present(rlheat))    rlheat(:) = cstate%f_rlheat(:)
 
@@ -1694,8 +1636,7 @@ contains
     if (present(t))         cstate%f_t(:) = t(:)
 
     ! Convert rhoa from mks to the scaled units.
-    if (present(rhoa_wet))  cstate%f_rhoa_wet(:) = (rhoa_wet(:) * &
-         (cstate%f_zmet(:)*cstate%f_xmet(:)*cstate%f_ymet(:))) / 1e6_f * 1e3_f
+    if (present(rhoa_wet))  cstate%f_rhoa_wet(:) = (rhoa_wet(:) * cstate%f_zmet(:)) / 1e6_f * 1e3_f
 
     return
   end subroutine CARMASTATE_SetState

--- a/csolve.F90
+++ b/csolve.F90
@@ -34,7 +34,6 @@ subroutine csolve(carma, cstate, ibin, ielem, rc)
 
   ! Local Variables
   integer                        :: igroup
-  real(kind=f)                   :: xyzmet(NZ)
   real(kind=f)                   :: ppd(NZ)
   real(kind=f)                   :: pls(NZ)
 
@@ -42,14 +41,11 @@ subroutine csolve(carma, cstate, ibin, ielem, rc)
   ! Define current group & particle number concentration element indices
   igroup = igelem(ielem)         ! particle group
 
-  ! Metric scaling factor
-  xyzmet = xmet(:) * ymet(:) * zmet(:)
-
   ! Compute total production rate due to coagulation
-  ppd = coagpe(:,ibin,ielem) / xyzmet(:)
+  ppd = coagpe(:,ibin,ielem) / zmet(:)
 
   ! Compute total loss rate due to coagulation
-  pls = coaglg(:,ibin,igroup) / xyzmet(:)
+  pls = coaglg(:,ibin,igroup) / zmet(:)
 
   ! Update net particle number concentration during current timestep
   ! due to production and loss rates for coagulation

--- a/gsolve.F90
+++ b/gsolve.F90
@@ -33,22 +33,22 @@ subroutine gsolve(carma, cstate, iz, previous_ice, previous_liquid, scale_thresh
   real(kind=f)                         :: total_ice(NGAS)      ! total ice
   real(kind=f)                         :: total_liquid(NGAS)   ! total liquid
   real(kind=f)                         :: threshold            ! convergence threshold
-  
-  
-  1 format(/,'gsolve::ERROR - negative gas concentration for ',a,' : iz=',i4,',lat=', &
-              f7.2,',lon=',f7.2,',gc=',e10.3,',gasprod=',e10.3,',supsati=',e10.3, &
+
+
+  1 format(/,'gsolve::ERROR - negative gas concentration for ',a,' : iz=',i4,',xc=', &
+              f7.2,',yc=',f7.2,',gc=',e10.3,',gasprod=',e10.3,',supsati=',e10.3, &
               ',supsatl=',e10.3,',t=',f6.2)
   2 format('gsolve::ERROR - conditions at beginning of the step : gc=',e10.3,',supsati=',e17.10, &
               ',supsatl=',e17.10,',t=',f6.2,',d_gc=',e10.3,',d_t=',f6.2)
-  3 format(/,'microfast::WARNING - gas concentration change exceeds threshold: ',a,' : iz=',i4,',lat=', &
-              f7.2,',lon=',f7.2, ', (gc-gcl)/gcl=', e10.3)
-  
+  3 format(/,'microfast::WARNING - gas concentration change exceeds threshold: ',a,' : iz=',i4,',xc=', &
+              f7.2,',yc=',f7.2, ', (gc-gcl)/gcl=', e10.3)
+
 
   ! Determine the total amount of condensate for each gas.
   call totalcondensate(carma, cstate, iz, total_ice, total_liquid, rc)
-  
+
   do igas = 1,NGAS
-  
+
     ! We do not seem to be conserving mass and energy, so rather than relying upon gasprod
     ! and rlheat, recalculate the total change in condensate to determine the change
     ! in gas and energy.
@@ -57,40 +57,40 @@ subroutine gsolve(carma, cstate, iz, previous_ice, previous_liquid, scale_thresh
     ! gas and latent heat were solved for explicitly using the same rates.
     gasprod(igas) = ((previous_ice(igas) - total_ice(igas)) + (previous_liquid(igas) - total_liquid(igas))) / dtime
     rlprod        = rlprod - ((previous_ice(igas) - total_ice(igas)) * (rlhe(iz,igas) + rlhm(iz,igas)) + &
-                       (previous_liquid(igas) - total_liquid(igas)) * (rlhe(iz,igas))) / (CP * rhoa(iz) * dtime)     
+                       (previous_liquid(igas) - total_liquid(igas)) * (rlhe(iz,igas))) / (CP * rhoa(iz) * dtime)
 
     ! Don't let the gas concentration go negative.
     gc(iz,igas) = gc(iz,igas) + dtime * gasprod(igas)
 
     if (gc(iz,igas) < 0.0_f) then
       if (do_substep) then
-        if (nretries == maxretries) then 
-          if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, lat, lon, gc(iz,igas), gasprod(igas), &
+        if (nretries == maxretries) then
+          if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, xc, yc, gc(iz,igas), gasprod(igas), &
             supsati(iz,igas), supsatl(iz,igas), t(iz)
           if (do_print) write(LUNOPRT,2) gcl(iz,igas), supsatiold(iz,igas), supsatlold(iz,igas), told(iz), d_gc(iz,igas), d_t(iz)
         end if
       else
-        if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, lat, lon, gc(iz,igas), gasprod(igas), &
+        if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, xc, yc, gc(iz,igas), gasprod(igas), &
           supsati(iz, igas), supsatl(iz,igas), t(iz)
       end if
 
       rc = RC_WARNING_RETRY
     end if
-    
+
     ! If gas changes by too much, then retry the calculation.
     threshold = dgc_threshold(igas) / scale_threshold
-    
+
     if (threshold /= 0._f) then
       if ((dtime * gasprod(igas) / gc(iz,igas)) > threshold) then
         if (do_substep) then
-          if (nretries == maxretries) then 
-            if (do_print) write(LUNOPRT,3) trim(gasname(igas)), iz, lat, lon, dtime * gasprod(igas) / gc(iz,igas)
+          if (nretries == maxretries) then
+            if (do_print) write(LUNOPRT,3) trim(gasname(igas)), iz, xc, yc, dtime * gasprod(igas) / gc(iz,igas)
             if (do_print) write(LUNOPRT,2) gcl(iz,igas), supsatiold(iz,igas), supsatlold(iz,igas), told(iz), d_gc(iz,igas), d_t(iz)
           end if
         else
-          if (do_print) write(LUNOPRT,3) trim(gasname(igas)), iz, lat, lon, dtime * gasprod(igas) / gc(iz,igas)
+          if (do_print) write(LUNOPRT,3) trim(gasname(igas)), iz, xc, yc, dtime * gasprod(igas) / gc(iz,igas)
         end if
-  
+
         rc = RC_WARNING_RETRY
       end if
     end if

--- a/lusolvec_mod.F90
+++ b/lusolvec_mod.F90
@@ -11,10 +11,10 @@
 !! matrix equation      A * x = b      to solve for vector x.
 !! 
 !!                                                                     
-!! First, call LUDCMPC(A,N,NP,INDX,D). The original Matrix A is lost   
+!! First, call LUDCMPC(A,N,numP,INDX,D). The original Matrix A is lost   
 !! and substituted by its LU decomposition.                            
 !!                                                                     
-!! Second, call LUBKSBC(A,N,NP,INDX,B). The original right-hand-side   
+!! Second, call LUBKSBC(A,N,numP,INDX,B). The original right-hand-side   
 !! vector ib in B is lost and replaced/returned as the solution        
 !! vector x  ( x(i) = B(i) ).                                          
 !! Use same kind of call to solve for successive right-hand-sides.     
@@ -24,7 +24,7 @@
 !!   1) Initialize matrix AINV(i,j) to be equal to the                 
 !!      identity matrix (AINV(i,j)=1 for i=j; =0 otherwise)            
 !!   2) DO jj=1,n                                                      
-!!         CALL LUBKSBC(A,N,NP,INDX,AINV(1,jj))                        
+!!         CALL LUBKSBC(A,N,numP,INDX,AINV(1,jj))                        
 !!      END DO                                                         
 !! (see textbook for further details).                                 
 !! ****************************************************************** 
@@ -48,7 +48,7 @@ module lusolvec_mod
   contains
 
   !!
-  !! SUBROUTINE LUDCMPC(A,N,NP,INDX,D)                                   
+  !! SUBROUTINE LUDCMPC(A,N,numP,INDX,D)                                   
   !!
   !! Given a general complex matrix A, this routine replaces it by its   
   !! LU decomposition of a rowwise permutation of itself.                
@@ -70,10 +70,10 @@ module lusolvec_mod
   !! ******************************************************************  
   !! Version: 28.08.2000                                                 
   !! ******************************************************************
-  SUBROUTINE LUDCMPC(A,N,NP,INDX,D)
+  SUBROUTINE LUDCMPC(A,N,numP,INDX,D)
 
-    INTEGER :: NP
-    COMPLEX(kind=f) :: A(NP,NP)
+    INTEGER :: numP
+    COMPLEX(kind=f) :: A(numP,numP)
     INTEGER :: N
     INTEGER :: INDX(N)
     REAL(kind=f) :: D
@@ -147,7 +147,7 @@ module lusolvec_mod
   END SUBROUTINE LUDCMPC
 
   !!
-  !! SUBROUTINE LUBKSBC(A,N,NP,INDX,B)
+  !! SUBROUTINE LUBKSBC(A,N,numP,INDX,B)
   !!
   !! Solution of the set of linear equations A' * x = b where 
   !! A is input not as the original matrix, but as a LU decomposition 
@@ -168,10 +168,10 @@ module lusolvec_mod
   !! ******************************************************************
   !! Version: 28.08.2000
   !! ******************************************************************
-  SUBROUTINE LUBKSBC(A,N,NP,INDX,B)
+  SUBROUTINE LUBKSBC(A,N,numP,INDX,B)
 
-    INTEGER :: NP
-    COMPLEX(kind=f) :: A(NP,NP)
+    INTEGER :: numP
+    COMPLEX(kind=f) :: A(numP,numP)
     INTEGER :: N
     INTEGER :: INDX(N)
     COMPLEX(kind=f) :: B(N)

--- a/maxconc.F90
+++ b/maxconc.F90
@@ -38,8 +38,6 @@ subroutine maxconc(carma, cstate, iz, rc)
     pconmax(iz,igrp) = maxval(pc(iz,:,iep))
 
     pconmax(iz,igrp) = pconmax(iz,igrp) &
-                            / xmet(iz)        &
-                            / ymet(iz)        &
                             / zmet(iz)
   enddo  ! igrp
 

--- a/microfast.F90
+++ b/microfast.F90
@@ -39,13 +39,13 @@ subroutine microfast(carma, cstate, iz, scale_threshold, rc)
   real(kind=f)                         :: srat2
   real(kind=f)                         :: s_threshold
 
-  1 format(/,'microfast::ERROR - excessive change in supersaturation for ',a,' : iz=',i4,',lat=', &
-              f7.2,',lon=',f7.2,',srat=',e10.3,',supsatiold=',e10.3,',supsatlold=',e10.3,',supsati=',e10.3, &
+  1 format(/,'microfast::ERROR - excessive change in supersaturation for ',a,' : iz=',i4,',xc=', &
+              f7.2,',yc=',f7.2,',srat=',e10.3,',supsatiold=',e10.3,',supsatlold=',e10.3,',supsati=',e10.3, &
               ',supsatl=',e10.3,',t=',f6.2)
   2 format('microfast::ERROR - conditions at beginning of the step : gc=',e10.3,',supsati=',e17.10, &
               ',supsatl=',e17.10,',t=',f6.2,',d_gc=',e10.3,',d_t=',f6.2)
-  3 format(/,'microfast::ERROR - excessive change in supersaturation for ',a,' : iz=',i4,',lat=', &
-              f7.2,',lon=',f7.2,',supsatiold=',e10.3,',supsatlold=',e10.3,',supsati=',e10.3, &
+  3 format(/,'microfast::ERROR - excessive change in supersaturation for ',a,' : iz=',i4,',xc=', &
+              f7.2,',yc=',f7.2,',supsatiold=',e10.3,',supsatlold=',e10.3,',supsati=',e10.3, &
               ',supsatl=',e10.3,',t=',f6.2)
 
    ! Set production and loss rates to zero.
@@ -217,7 +217,7 @@ subroutine microfast(carma, cstate, iz, scale_threshold, rc)
             if (do_substep) then
               if (nretries == maxretries) then
                 if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, &
-                     lat, lon, srat, previous_supsati(igas), previous_supsatl(igas), &
+                     xc, yc, srat, previous_supsati(igas), previous_supsatl(igas), &
                      supsati(iz, igas), supsatl(iz,igas), t(iz)
                 if (do_print) write(LUNOPRT,2) gcl(iz,igas), supsatiold(iz, igas), &
                      supsatlold(iz,igas), told(iz), d_gc(iz, igas), d_t(iz)
@@ -225,7 +225,7 @@ subroutine microfast(carma, cstate, iz, scale_threshold, rc)
 
               rc = RC_WARNING_RETRY
             else
-              if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, lat, lon, &
+              if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, xc, yc, &
                    srat, previous_supsati(igas), previous_supsatl(igas), &
                    supsati(iz, igas), supsatl(iz,igas), t(iz)
             end if
@@ -264,14 +264,14 @@ subroutine microfast(carma, cstate, iz, scale_threshold, rc)
           if (do_substep) then
             if (nretries == maxretries) then
               if (do_print) write(LUNOPRT,3) trim(gasname(igas)), iz, &
-                   lat, lon, previous_supsati(igas), previous_supsatl(igas), &
+                   xc, yc, previous_supsati(igas), previous_supsatl(igas), &
                    supsati(iz, igas), supsatl(iz,igas), t(iz)
               if (do_print) write(LUNOPRT,2) gcl(iz,igas), supsatiold(iz, igas), &
                    supsatlold(iz,igas), told(iz), d_gc(iz, igas), d_t(iz)
             end if
           else
             if (do_print) write(LUNOPRT,3) trim(gasname(igas)), iz, &
-                 lat, lon, previous_supsati(igas), previous_supsatl(igas), &
+                 xc, yc, previous_supsati(igas), previous_supsatl(igas), &
                  supsati(iz, igas), supsatl(iz,igas), t(iz)
           end if
 

--- a/nsubsteps.F90
+++ b/nsubsteps.F90
@@ -47,40 +47,40 @@ subroutine nsubsteps(carma, cstate, iz, dtime_save, ntsubsteps, rc)
   ! If substepping is disabled, then use one substep
   if (.not. do_substep) then
     ntsubsteps = 1
-  else 
+  else
     ! Set default values
     ntsubsteps = minsubsteps
-    
+
     ! Find the bin number of the smallest particle bin that
     ! contains a significant number of particles.
     ! Also check for significant activation of water droplets.
-  
+
     if( ntsubsteps .lt. maxsubsteps )then
-  
+
       do ig = 1, NGROUP
-  
+
         if( pconmax(iz,ig) .gt. FEW_PC) then
-  
+
           ibin_small(ig) = NBIN
 
-          ! element of particle number concentration  
+          ! element of particle number concentration
           iepart = ienconc(ig)
-          
+
           if( itype(iepart) .eq. I_INVOLATILE ) then
-  
+
             ! condensing gas
             igas = inucgas(ig)
-  
+
             if (igas /= 0) then
-          
+
               ss = max( supsatl(iz,igas), supsatlold(iz,igas) )
-  
+
               do inuc = 1,nnuc2elem(iepart)
                 ienucto = inuc2elem(inuc,iepart)
-    
+
                 if( inucproc(iepart,ienucto) .eq. I_DROPACT ) then
                   do ibin = 1, NBIN
-                    if( pc(iz,ibin,iepart) / xmet(iz) / ymet(iz) / zmet(iz) .gt. conmax * pconmax(iz,ig) .and. &
+                    if( pc(iz,ibin,iepart) / zmet(iz) .gt. conmax * pconmax(iz,ig) .and. &
                         ss .gt. scrit(iz,ibin,ig) )then
                       ntsubsteps = maxsubsteps
                     endif
@@ -88,40 +88,40 @@ subroutine nsubsteps(carma, cstate, iz, dtime_save, ntsubsteps, rc)
                 endif
               enddo
             endif
-  
+
           elseif( itype(iepart) .eq. I_VOLATILE ) then
-          
+
             do ibin = NBIN-1, 1, -1
-              if( pc(iz,ibin,iepart) / xmet(iz) / ymet(iz) / zmet(iz) .gt. conmax * pconmax(iz,ig) )then
+              if( pc(iz,ibin,iepart) / zmet(iz) .gt. conmax * pconmax(iz,ig) )then
                 ibin_small(ig) = ibin
               endif
             enddo
-  
+
           endif
         endif
       enddo
     endif
-  
+
     ! Calculate the growth rate of a particle with the mode radius for
     ! each volatile group.  The maximum time-step to use is then the
     ! mass growth rate divided by the mass bin width / 2.
     if( ntsubsteps .lt. maxsubsteps )then
-  
+
       dt_adv = dtime_save
       do ig = 1, NGROUP
-      
+
         ! element of particle number concentration
         iepart = ienconc(ig)
-        
+
         ! condensing gas
         igas = igrowgas(iepart)
 
         if (igas /= 0) then
-  
+
           if( pconmax(iz,ig) .gt. FEW_PC ) then
-    
+
             if( itype(iepart) .eq. I_VOLATILE ) then
-    
+
               if( is_grp_ice(ig) )then
                 ss = supsati(iz,igas)
                 pvap = pvapi(iz,igas)
@@ -129,11 +129,11 @@ subroutine nsubsteps(carma, cstate, iz, dtime_save, ntsubsteps, rc)
                 ss = supsatl(iz,igas)
                 pvap = pvapl(iz,igas)
               endif
-    
+
               g0 = gro(iz,ibin_small(ig),ig)
               g1 = gro1(iz,ibin_small(ig),ig)
               dmdt = abs( pvap * ss * g0 / ( 1._f + g0*g1*pvap ) )
-              
+
               if (dmdt /= 0._f) then
                 dt_adv = min( dt_adv, dm(ibin_small(ig),ig)/dmdt )
               end if
@@ -141,7 +141,7 @@ subroutine nsubsteps(carma, cstate, iz, dtime_save, ntsubsteps, rc)
           endif
         endif
       enddo
-  
+
       ntsubsteps = nint(min(real(maxsubsteps, kind=f), real(dtime_save, kind=f) / dt_adv))
       ntsubsteps = max( minsubsteps, ntsubsteps )
     endif
@@ -150,18 +150,18 @@ subroutine nsubsteps(carma, cstate, iz, dtime_save, ntsubsteps, rc)
     ! of sulfate aerosols, then use maximum number of substeps
     if( ntsubsteps .lt. (maxsubsteps) )then
       do ig = 1, NGROUP
-      
-        ! element of particle number concentration  
+
+        ! element of particle number concentration
         iepart = ienconc(ig)
 
         ! condensing gas
         igas = inucgas(ig)
 
         if (igas /= 0) then
-          
+
           do inuc = 1,nnuc2elem(iepart)
             ienucto = inuc2elem(inuc,iepart)
-    
+
             if (iand(inucproc(iepart,ienucto), I_AERFREEZE) .ne. 0) then
               if( (supsati(iz,igas) .gt. 0.4_f) .and. (t(iz) .lt. 233.16_f) ) then
                 ntsubsteps = maxsubsteps

--- a/rhopart.F90
+++ b/rhopart.F90
@@ -122,7 +122,7 @@ subroutine rhopart(carma, cstate, rc)
 
       ! Determine the weight percent of sulfate, and store it for later use.
       if (irhswell(igroup) == I_WTPCT_H2SO4 .or. irhswell(igroup) == I_PETTERS) then
-        h2o_mass     = gc(iz, igash2o) / (xmet(iz) * ymet(iz) * zmet(iz))
+        h2o_mass     = gc(iz, igash2o) / zmet(iz)
       end if
 
       ! Loop over particle size bins.

--- a/setupatm.F90
+++ b/setupatm.F90
@@ -5,7 +5,7 @@
 !! This routine setups up parameters related to the atmospheric state. It assumes that the
 !! pressure, temperature, and dimensional fields (xc, dx, yc, dy, zc, zl) have already been
 !! specified and all state arrays allocated via CARMASTATE_Create().
-!! 
+!!
 !! @author Chuck Bardeen
 !! @ version Feb-1995
 !! @see CARMASTATE_Create
@@ -32,11 +32,11 @@ subroutine setupatm(carma, cstate, rescale, rc)
   ! Air viscosity <rmu> is from Sutherland's equation (using Smithsonian
   !   Meteorological Tables, in which there is a misprint -- T is deg_K, not
   !   deg_C.
-  real(kind=f), parameter :: rmu_0 = 1.8325e-4_f  
-  real(kind=f), parameter :: rmu_t0 = 296.16_f     
-  real(kind=f), parameter :: rmu_c = 120._f        
+  real(kind=f), parameter :: rmu_0 = 1.8325e-4_f
+  real(kind=f), parameter :: rmu_t0 = 296.16_f
+  real(kind=f), parameter :: rmu_c = 120._f
   real(kind=f), parameter :: rmu_const = rmu_0 * (rmu_t0 + rmu_c)
-    
+
   integer :: ielem, ibin, i, j, ix, iy, iz, ie, ig, ip, igrp, jgrp, igroup
 
 
@@ -46,26 +46,7 @@ subroutine setupatm(carma, cstate, rescale, rc)
 
   ! Calculate the dimensions and the dimensional metrics.
   dz(:) = abs(zl(2:NZP1) - zl(1:NZ))
-  
-  ! Horizontal Metrics
-  select case(igridh)
-    ! Cartesian
-    case (I_CART)
-      xmet(:) = 1._f
-      ymet(:) = 1._f
-    
-    ! Latitude/Longitude
-    case (I_LL)
-      xmet(:) = REARTH * DEG2RAD * cos(DEG2RAD * yc(:))
-      ymet(:) = REARTH * DEG2RAD
-      
-    case default
-      if (do_print) write(LUNOPRT,*) "setupatm:: ERROR - The specified horizontal grid type (", igridh, &
-        ") is not supported."
-      rc = -1
-  end select
 
-  
   ! Put the fall velocity back into cgs units, so that we can determine
   ! new metrics and then scale it back. This is optional and is done instead
   ! of recalculating everything from scratch to improve performance.
@@ -78,38 +59,38 @@ subroutine setupatm(carma, cstate, rescale, rc)
     end do
   end if
 
- 
+
   ! Vertical Metrics
   select case(igridv)
     ! Cartesian
     case (I_CART)
       zmet = 1._f
-      
+
     ! Sigma
     case (I_SIG)
       zmet(:) = abs(((pl(1:NZ) - pl(2:NZP1)) / (zl(1:NZ) - zl(2:NZP1))) / &
         (GRAV * rhoa(:)))
-        
+
     ! Hybrid
     case (I_HYBRID)
       zmet(:) = abs(((pl(1:NZ) - pl(2:NZP1)) / (zl(1:NZ) - zl(2:NZP1))) / &
         (GRAV * rhoa(:)))
-        
+
     case default
       if (do_print) write(LUNOPRT,*) "setupatm:: ERROR - The specified vertical grid type (", igridv, &
         ") is not supported."
       rc = -1
   end select
- 
+
   ! Interpolate the z metric to the grid box edges.
   if (NZ == 1) then
     zmetl(:) = zmet(1)
   else
-    
+
     ! Extrpolate the top and bottom.
     zmetl(1)    = zmet(1)  + (zmet(2) - zmet(1))     / (zc(2) - zc(1))     * (zl(1) - zc(1))
     zmetl(NZP1) = zmet(NZ) + (zmet(NZ) - zmet(NZ-1)) / (zc(NZ) - zc(NZ-1)) * (zl(NZP1) - zc(NZ))
-    
+
     ! Interpolate the middles.
     if (NZ > 2) then
       do iz = 2, NZ
@@ -118,7 +99,7 @@ subroutine setupatm(carma, cstate, rescale, rc)
     end if
   end if
 
- 
+
   ! Determine the z metrics at the grid box edges and then use this to put the
   ! fall velocity back into /x/y/z units.
   if (rescale .and. (igridv /= I_CART)) then
@@ -129,16 +110,16 @@ subroutine setupatm(carma, cstate, rescale, rc)
       end do
     end do
   end if
-  
-  
-  ! Scale the density into the units carma wants (i.e. /x/y/z)     
-  rhoa(:) = rhoa(:) * xmet(:) * ymet(:) * zmet(:)
 
-  ! Use the pressure difference across the cell and the fact that the 
+
+  ! Scale the density into the units carma wants (i.e. /x/y/z)
+  rhoa(:) = rhoa(:) * zmet(:)
+
+  ! Use the pressure difference across the cell and the fact that the
   ! atmosphere is hydrostatic to caclulate an average density in the
   ! grid box.
   rhoa_wet(:) = abs((pl(2:NZP1) - pl(1:NZ))) / (GRAV)
-  rhoa_wet(:) = (rhoa_wet(:) * xmet(:) * ymet(:)) / dz(:)
+  rhoa_wet(:) = rhoa_wet(:) / dz(:)
 
   ! Calculate the thermal properties of the atmosphere.
   rmu(:)     = rmu_const / ( t(:) + rmu_c ) * (t(:) / rmu_t0 )**1.5_f

--- a/setupckern.F90
+++ b/setupckern.F90
@@ -12,8 +12,8 @@
 !!  This routine requires that vertical profiles of temperature <T>,
 !!  air density <rhoa>, and viscosity <rmu> are defined.
 !!
-!!  @version Oct-1995  
-!!  @author  Andy Ackerman 
+!!  @version Oct-1995
+!!  @author  Andy Ackerman
 subroutine setupckern(carma, cstate, rc)
 
   ! types
@@ -23,13 +23,13 @@ subroutine setupckern(carma, cstate, rc)
   use carma_types_mod
   use carmastate_mod
   use carma_mod
-  
+
   implicit none
 
   type(carma_type), intent(in)         :: carma   !! the carma object
   type(carmastate_type), intent(inout) :: cstate  !! the carma state object
   integer, intent(inout)               :: rc      !! return code, negative indicates failure
-  
+
   ! Local declarations
   ! 2-D collision efficiency for current group pair under
   ! consideration (for extrapolation of input data)
@@ -41,7 +41,7 @@ subroutine setupckern(carma, cstate, rc)
   real(kind=f), save      :: data_p(NP_DATA)          ! radius ratios (collected/collector)
   real(kind=f), save      :: data_r(NR_DATA)          ! collector drop radii (um)
   real(kind=f), save      :: data_e(NP_DATA, NR_DATA) ! geometric collection efficiencies
-      
+
   integer :: ip
   integer :: ig, jg
 
@@ -68,10 +68,10 @@ subroutine setupckern(carma, cstate, rc)
   real(kind=f) :: r2
   real(kind=f) :: dj
   real(kind=f) :: gj
-  real(kind=f) :: rlbj 
+  real(kind=f) :: rlbj
   real(kind=f) :: dtj1
-  real(kind=f) :: dtj2 
-  real(kind=f) :: dtj 
+  real(kind=f) :: dtj2
+  real(kind=f) :: dtj
 
   real(kind=f) :: rp
   real(kind=f) :: dp
@@ -90,42 +90,42 @@ subroutine setupckern(carma, cstate, rc)
   real(kind=f) :: d_larg
 
   real(kind=f) :: re_larg
-  real(kind=f) :: pe 
-  real(kind=f) :: pe3 
-  real(kind=f) :: ccd 
+  real(kind=f) :: pe
+  real(kind=f) :: pe3
+  real(kind=f) :: ccd
 
   real(kind=f) :: e_coll
   real(kind=f) :: vfc_smal
-  real(kind=f) :: vfc_larg 
+  real(kind=f) :: vfc_larg
   real(kind=f) :: sk
   real(kind=f) :: e1
   real(kind=f) :: e3
   real(kind=f) :: e_langmuir
   real(kind=f) :: re60
 
-  real(kind=f) :: pr 
+  real(kind=f) :: pr
   real(kind=f) :: e_fuchs
 
   integer :: jp, jj, jr
 
   real(kind=f) :: pblni
-  real(kind=f) :: rblni 
+  real(kind=f) :: rblni
 
   real(kind=f) :: term3
   real(kind=f) :: term4
 
   real(kind=f) :: beta
   real(kind=f) :: b_coal
-  real(kind=f) :: a_coal 
-  real(kind=f) :: x_coal 
+  real(kind=f) :: a_coal
+  real(kind=f) :: x_coal
   real(kind=f) :: e_coal
   real(kind=f) :: vfc_1
   real(kind=f) :: vfc_2
-  real(kind=f) :: cgr 
-  
+  real(kind=f) :: cgr
+
 
 !  Add constants for calculating effect of Van Der Waal's forces on coagulation
-!  See Chan and Mozurkewich, J. Atmos. Sci., June 2001  
+!  See Chan and Mozurkewich, J. Atmos. Sci., June 2001
   real(kind=f), parameter :: vwa1 = 0.0757_f
   real(kind=f), parameter :: vwa3 = 0.0015_f
   real(kind=f), parameter :: vwb0 = 0.0151_f
@@ -135,7 +135,7 @@ subroutine setupckern(carma, cstate, rc)
   real(kind=f) :: hp, hpln, Enot, Einf
   logical      :: use_vw(NGROUP, NGROUP)
   integer      :: ielem
-  
+
 
 !  Initialization of input data for gravitational collection.
 !  The data were compiled by Hall (J. Atmos. Sci. 37, 2486-2507, 1980).
@@ -197,9 +197,9 @@ subroutine setupckern(carma, cstate, rc)
   if( icoagop .eq. I_COAGOP_CONST )then
     ckernel(:,:,:,:,:) = ck0
   else
- 
+
     if( icollec .eq. I_COLLEC_DATA )then
-    
+
       ! Convert <data_r> from um to cm and take logarithm of <data_e>;
       ! however, we only want to do this once.
       !
@@ -209,7 +209,7 @@ subroutine setupckern(carma, cstate, rc)
       !$OMP CRITICAL(CARMA_HALL)
       if (.not. init_data) then
         init_data = .TRUE.
-        
+
         do i = 1, NR_DATA
           data_r(i) = data_r(i)/1.e4_f
           do ip = 1, NP_DATA
@@ -219,31 +219,31 @@ subroutine setupckern(carma, cstate, rc)
       endif
       !$OMP END CRITICAL(CARMA_HALL)
     endif
-   
+
     ! Loop over the grid
     do k = 1, NZ
-    
+
       ! This is <rhoa> in cartesian coordinates.
-      rhoa_cgs = rhoa(k) / (xmet(k)*ymet(k)*zmet(k))
-  
+      rhoa_cgs = rhoa(k) / zmet(k)
+
       temp1 = BK*t(k)
       temp2 = 6._f*PI*rmu(k)
-      
+
       do j1 = 1, NGROUP
         do j2 = j1, NGROUP
           use_vw(j1, j2) = is_grp_sulfate(j1) .and. is_grp_sulfate(j2)
         end do
       end do
-  
+
       ! Loop over groups!
       do j1 = 1, NGROUP
         do j2 = 1, NGROUP
-    
+
           if( icoag(j1,j2) .ne. 0 )then
-  
+
             ! First particle
             do i1 = 1, NBIN
-                  
+
               r1 = r_wet(k,i1,j1) * rrat(i1,j1)
               di = temp1*bpm(k,i1,j1)/(temp2*r1)
               gi  = sqrt( 8._f*temp1/(PI*rmass(i1,j1)) )
@@ -252,7 +252,7 @@ subroutine setupckern(carma, cstate, rc)
               dti2= (4._f*r1*r1 + rlbi*rlbi)**1.5_f
               dti = 1._f/(6._f*r1*rlbi)
               dti = dti*(dti1 - dti2) - 2._f*r1
-  
+
               !  Second particle
               do i2 = 1, NBIN
                 r2  = r_wet(k,i2,j2) * rrat(i2,j2)
@@ -263,11 +263,11 @@ subroutine setupckern(carma, cstate, rc)
                 dtj2= (4._f*r2*r2 + rlbj*rlbj)**1.5_f
                 dtj = 1._f/(6._f*r2*rlbj)
                 dtj = dtj*(dtj1 - dtj2) - 2._f*r2
-                
-                !  Account for the charging effect of small particles (Van Der Waal's forces).  
+
+                !  Account for the charging effect of small particles (Van Der Waal's forces).
                 !  Set cstick to E_infinity/Eo, then multiply cbr kernel by Eo
                 !  See Chan and Mozurkewich, J. Atmos. Sci., June 2001
-                !  Only applicable to groups with sulfate elements    
+                !  Only applicable to groups with sulfate elements
                 if (use_vw(j1,j2)) then
                   hp = ham / temp1 * (4._f * r1 * r2 / (r1 + r2)**2)
                   hpln = log(1._f + hp)
@@ -285,10 +285,10 @@ subroutine setupckern(carma, cstate, rc)
                 delt= sqrt(dti*dti + dtj*dtj)
                 term1 = rp/(rp + delt)
                 term2 = 4._f*dp/(gg*rp)
-  
+
                 ! <cbr> is thermal (brownian) coagulation coefficient
                 cbr = 4._f*PI*rp*dp/(term1 + term2)
-  
+
                 ! Determine indices of larger and smaller particles (of the pair)
                 if (r2 .ge. r1) then
                   r_larg = r2
@@ -307,26 +307,26 @@ subroutine setupckern(carma, cstate, rc)
                   ig_smal = j2
                   d_larg  = di
                 endif
-                
-                ! Calculate enhancement of coagulation due to convective diffusion 
+
+                ! Calculate enhancement of coagulation due to convective diffusion
                 ! as described in Pruppacher and Klett (Eqs. 17-12 and 17-14).
-  
+
                 ! Enhancement applies to larger particle.
                 re_larg = re(k,i_larg,ig_larg)
-  
+
                 ! <pe> is Peclet number.
                 pe  = re_larg*rmu(k) / (rhoa_cgs*d_larg)
                 pe3 = pe**(1._f/3._f)
-                
+
                 ! <ccd> is convective diffusion coagulation coefficient
                 if( re_larg .lt. 1._f )then
                   ccd = 0.45_f*cbr*pe3
-                else 
+                else
                   ccd = 0.45_f*cbr*pe3*re_larg**(ONE/6._f)
                 endif
-  
-                ! Next calculate gravitational collection kernel.  
-                
+
+                ! Next calculate gravitational collection kernel.
+
                 ! First evaluate collection efficiency <e>.
                 if( icollec .eq. I_COLLEC_CONST )then
                   !   constant value
@@ -334,26 +334,26 @@ subroutine setupckern(carma, cstate, rc)
                 else if( icollec .eq. I_COLLEC_FUCHS )then
                   ! Find maximum of Langmuir's formulation and Fuchs' value.
                   ! First calculate Langmuir's efficiency <e_langmuir>.
-  
+
                   ! <sk> is stokes number.
                   ! <vfc_{larg,smal}> is the fallspeed in cartesian coordinates.!
                   vfc_smal = vf(k,i_smal,ig_smal) * zmet(k)
                   vfc_larg = vf(k,i_larg,ig_larg) * zmet(k)
-  
+
                   sk = vfc_smal * (vfc_larg - vfc_smal) / (r_larg*GRAV)
-     
+
                   if( sk .lt. 0.08333334_f )then
                     e1 = 0._f
-                  else 
+                  else
                     e1 = (sk/(sk + 0.25_f))**2
                   endif
-     
+
                   if( sk .lt. 1.214_f )then
                     e3  = 0._f
                   else
                     e3  = 1._f/(1._f+.75_f*log(2._f*sk)/(sk-1.214_f))**2
                   endif
-     
+
                   if( re_larg .lt. 1._f )then
                     e_langmuir = e3
                   else if( re_larg .gt. 1000._f )then
@@ -362,21 +362,21 @@ subroutine setupckern(carma, cstate, rc)
                     re60 = re_larg/60._f
                     e_langmuir = (e3  + re60*e1)/(1._f + re60)
                   endif
-  
+
                   ! Next calculate Fuchs' efficiency (valid for r < 10 um).
                   pr = r_smal/r_larg
                   e_fuchs   = (pr/(1.414_f*(1. + pr)))**2
-    
+
                   e_coll = max( e_fuchs, e_langmuir )
-  
+
                 else if( icollec .eq. I_COLLEC_DATA )then
-  
+
                   ! Interpolate input data (from data statment at beginning of subroutine).
                   pr = r_smal/r_larg
-  
+
                   ! First treat cases outside the data range
                   if( pr .lt. data_p(2) )then
-  
+
                     ! Radius ratio is smaller than lowest nonzero ratio in input data --
                     ! use constant values (as in Beard and Ochs, 1984) if available,
                     ! otherwise use very small efficiencty
@@ -393,24 +393,24 @@ subroutine setupckern(carma, cstate, rc)
                         e_coll = e_coll2(i1-1,i2)
                       endif
                     endif
-    
+
                   elseif( r_larg .lt. data_r(1) )then
-                    ! Radius of larger particle is smaller than smallest radius in input data -- 
+                    ! Radius of larger particle is smaller than smallest radius in input data --
                     ! assign very small efficiency.
                     e_coll = e_small
                   else
-  
+
                     ! Both droplets are either within grid (interpolate) or larger
-                    ! droplet is larger than maximum on grid (extrapolate) -- in both cases 
+                    ! droplet is larger than maximum on grid (extrapolate) -- in both cases
                     ! will interpolate on ratio of droplet radii.
-  
+
                     ! Find <jp> such that data_p(jp) <= pr <= data_p(jp+1) and calculate
-                    ! <pblni> = fractional distance of <pr> between points in <data_p> 
+                    ! <pblni> = fractional distance of <pr> between points in <data_p>
                     jp = NP_DATA
                     do jj = NP_DATA-1, 2, -1
                       if( pr .le. data_p(jj+1) ) jp = jj
                     enddo
-                    
+
                     ! should not need this if-stmt
                     if( jp .lt. NP_DATA )then
                       pblni = (pr - data_p(jp)) / (data_p(jp+1) - data_p(jp))
@@ -419,18 +419,18 @@ subroutine setupckern(carma, cstate, rc)
                       if (do_print) write(LUNOPRT, *) 'setupckern::ERROR NP_DATA < jp = ', jp
                       return
                     endif
-  
+
                     if( r_larg .gt. data_r(NR_DATA) )then
-  
-                      ! Extrapolate on R and interpolate on p 
+
+                      ! Extrapolate on R and interpolate on p
                       !
                       ! NOTE: This expression has a bugin it, since jr won't
                       ! be defined.
                       e_coll = (1._f-pblni)*data_e(jp  ,jr) + &
                                (   pblni)*data_e(jp+1,jr)
-  
+
                     else
-  
+
                       ! Find <jr> such that data_r(jr) <= r_larg <= data_r(jr+1) and calculate
                       ! <rblni> = fractional distance of <r_larg> between points in <data_r>
                       jr = NR_DATA
@@ -438,42 +438,42 @@ subroutine setupckern(carma, cstate, rc)
                         if( r_larg .le. data_r(jj+1) ) jr = jj
                       enddo
                       rblni = (r_larg - data_r(jr)) / (data_r(jr+1) - data_r(jr))
-   
+
                       ! Bilinear interpolation of logarithm of data.
                       e_coll = (1._f-pblni)*(1._f-rblni)*data_e(jp  ,jr  ) + &
                                (   pblni)*(1._f-rblni)*data_e(jp+1,jr  ) + &
                                (1._f-pblni)*(   rblni)*data_e(jp  ,jr+1) + &
-                               (   pblni)*(   rblni)*data_e(jp+1,jr+1)  
-  
+                               (   pblni)*(   rblni)*data_e(jp+1,jr+1)
+
                       ! (since data_e is logarithm of efficiencies)
                       term1 = (1._f-rblni)*(1._f-pblni)*data_e(jp,jr)
-                      
+
                       if( jp .lt. NP_DATA )then
                         term2 = pblni*(1.-rblni)*data_e(jp+1,jr)
                       else
                         term2 = -100._f
                       endif
-                      
+
                       if( jr .lt. NR_DATA )then
                         term3 = (1._f-pblni)*rblni*data_e(jp,jr+1)
                       else
                         term3 = -100._f
                       endif
-                      
+
                       if( jr .lt. NR_DATA .and. jp .lt. NP_DATA )then
                         term4 = pblni*rblni*data_e(jp+1,jr+1)
                       else
                         term4 = -100._f
                       endif
-  
+
                       e_coll = exp(term1 + term2 + term3 + term4)
                     endif
                   endif
-  
+
                   e_coll2(i1,i2) = e_coll
                 endif
-  
-                ! Now calculate coalescence efficiency from Beard and Ochs 
+
+                ! Now calculate coalescence efficiency from Beard and Ochs
                 ! (J. Geophys. Res. 89, 7165-7169, 1984).
                 beta = log(r_smal*1.e4_f) + 0.44_f*log(r_larg*50._f)
                 b_coal = 0.0946_f*beta - 0.319_f
@@ -481,43 +481,43 @@ subroutine setupckern(carma, cstate, rc)
                 x_coal = (a_coal-b_coal)**(ONE/3._f) &
                        - (a_coal+b_coal)**(ONE/3._f)
                 x_coal = x_coal + 0.459_f
-  
+
                 ! Limit extrapolated values to no less than 50% and no more than 100%
                 x_coal = max(x_coal,.5_f)
                 e_coal = min(x_coal,1._f)
-  
+
                 ! Now use coalescence efficiency and collision efficiency in definition
                 ! of (geometric) gravitational collection efficiency <cgr>.
                 vfc_1 = vf(k,i1,j1) * zmet(k)
                 vfc_2 = vf(k,i2,j2) * zmet(k)
                 cgr = e_coal * e_coll *  PI * rp**2 * abs( vfc_1 - vfc_2 )
-  
+
                 ! Long's (1974) kernel that only depends on size of larger droplet
   !                 if( r_larg .le. 50.e-4_f )then
   !                   cgr = 1.1e10_f * vol(i_larg,ig_larg)**2
   !                 else
   !                   cgr = 6.33e3_f * vol(i_larg,ig_larg)
   !                 endif
-  
+
                 ! Now combine all the coagulation and collection kernels into the
                 ! overall kernel.
                 ckernel(k,i1,i2,j1,j2) = cbr + ccd + cgr
-                
+
                 ! To avoid generation of large, non-physical hydrometeors by
                 ! coagulation, cut down ckernel for large radii
   !                 if( ( r1 .gt. 0.18_f .and. r2 .gt. 10.e-4_f ) .or. &
   !                     ( r2 .gt. 0.18_f .and. r1 .gt. 10.e-4_f ) ) then
   !                   ckernel(k,i1,i2,j1,j2) = ckernel(k,i1,i2,j1,j2) / 1.e6_f
   !                 endif
-  
+
               enddo    ! second particle bin
             enddo    ! first particle bin
-          endif     ! icoag ne 0 
+          endif     ! icoag ne 0
         enddo     ! second particle group
       enddo     ! first particle group
     enddo     ! vertical level
   endif     ! not constant
-  
+
   ! return to caller with coagulation kernels evaluated.
   return
 end

--- a/setupgrow.F90
+++ b/setupgrow.F90
@@ -5,7 +5,7 @@
 !! This routine defines time-independent parameters used to calculate
 !! condensational growth/evaporation.
 !!
-!! The parameters defined for each gas are 
+!! The parameters defined for each gas are
 !1>
 !!   gwtmol:   molecular weight [g/mol]
 !!   diffus:   diffusivity      [cm^2/s]
@@ -35,7 +35,7 @@ subroutine setupgrow(carma, cstate, rc)
   type(carma_type), intent(in)         :: carma   !! the carma object
   type(carmastate_type), intent(inout) :: cstate  !! the carma state object
   integer, intent(inout)               :: rc       !! return code, negative indicates failure
-  
+
   ! Local Variable
   integer                        :: ielem    !! element index
   integer                        :: k        !! z index
@@ -63,22 +63,22 @@ subroutine setupgrow(carma, cstate, rc)
 
     ! Diffusivity of water vapor in air from Pruppacher & Klett (eq. 13-3);
     ! units are [cm^2/s].
-    if (igash2o /= 0) then 
+    if (igash2o /= 0) then
       diffus(k, igash2o) = 0.211_f * (1.01325e+6_f / p(k)) * (t(k) / 273.15_f )**1.94_f
-  
+
       ! Latent heat of evaporation for water; units are [cm^2/s^2]
       if (do_cnst_rlh) then
         rlhe(k, igash2o) = RLHE_CNST
       else
         ! from Stull
-        rlhe(k, igash2o) = (2.5_f - .00239_f * (t(k) - 273.16_f)) * 1.e10_f      
+        rlhe(k, igash2o) = (2.5_f - .00239_f * (t(k) - 273.16_f)) * 1.e10_f
       end if
-  
+
       ! Latent heat of ice melting; units are [cm^2/s^2]
       if (do_cnst_rlh) then
         rlhm(k, igash2o) = RLHM_CNST
       else
-  
+
         ! from Pruppacher & Klett (eq. 4-85b)
         !
         ! NOTE: This expression yields negative values for rlmh at mesospheric
@@ -91,15 +91,15 @@ subroutine setupgrow(carma, cstate, rc)
     ! Properties for H2SO4
     if (igash2so4 /= 0) then
       ! Diffusivity
-      rhoa_cgs = rhoa(k) / (xmet(k) * ymet(k) * zmet(k))
+      rhoa_cgs = rhoa(k) / zmet(k)
       aden     = rhoa_cgs * AVG / WTMOL_AIR
       diffus(k,igash2so4) = 1.76575e+17_f * sqrt(t(k)) / aden
-  
+
       ! HACK: make H2SO4 latent heats same as water
       rlhe(k,igash2so4) = rlhe(k, igash2o)
       rlhm(k,igash2so4) = rlhe(k, igash2o)
     end if
-    
+
   enddo
 
 #ifdef CARMA_DEBUG

--- a/setupvf_heymsfield2010.F90
+++ b/setupvf_heymsfield2010.F90
@@ -13,7 +13,7 @@
 !! based upon the formulation of Schmitt and Heymsfield [JAS, 2009].
 !!
 !! @author  Chuck Bardeen
-!! @version Mar-2010 
+!! @version Mar-2010
 subroutine setupvf_heymsfield2010(carma, cstate, j, rc)
 
   ! types
@@ -36,15 +36,15 @@ subroutine setupvf_heymsfield2010(carma, cstate, j, rc)
   real(kind=f)             :: rhoa_cgs, vg, rmfp, rkn, expon, x
   real(kind=f), parameter  :: c0      = 0.35_f
   real(kind=f), parameter  :: delta0  = 8.0_f
-  
+
   real(kind=f)             :: dmax                ! maximum diameter
-  
-  
+
+
   ! Loop over all atltitudes.
   do k = 1, NZ
 
     ! This is <rhoa> in cartesian coordinates (good old cgs units)
-    rhoa_cgs = rhoa(k) / (xmet(k)*ymet(k)*zmet(k))
+    rhoa_cgs = rhoa(k) / zmet(k)
 
     ! <vg> is mean thermal velocity of air molecules [cm/s]
     vg = sqrt(8._f / PI * R_AIR * t(k))
@@ -54,10 +54,10 @@ subroutine setupvf_heymsfield2010(carma, cstate, j, rc)
 
     ! Loop over particle size bins.
     do i = 1,NBIN
-    
+
       ! <rkn> is knudsen number
-!      rkn = rmfp / r(i,j) 
-      rkn = rmfp / (r_wet(k,i,j) * rrat(i,j)) 
+!      rkn = rmfp / r(i,j)
+      rkn = rmfp / (r_wet(k,i,j) * rrat(i,j))
 
       ! <bpm> is the slip correction factor, the correction term for
       ! non-continuum effects.  Also used to calculate coagulation kernels
@@ -67,24 +67,24 @@ subroutine setupvf_heymsfield2010(carma, cstate, j, rc)
       bpm(k,i,j) = 1._f + (1.246_f*rkn + 0.42_f*rkn*exp(expon))
 
       dmax = 2._f * r_wet(k,i,j) * rrat(i,j)
-      
+
       x = (rhoa_cgs / (rmu(k)**2)) * &
            ((8._f * rmass(i,j) * GRAV) / (PI * (arat(i,j)**0.5_f)))
-      
+
       ! Apply the slip correction factor. This is not included in the formulation
       ! from Heymsfield and Westbrook [2010].
       !
       ! NOTE: This is applied according to eq 8.46 and surrounding discussion in
       ! Seinfeld and Pandis [1998].
       x = x * bpm(k,i,j)
-      
+
       re(k,i,j) = ((delta0**2) / 4._f) * (sqrt(1._f + (4._f * sqrt(x) / (delta0**2 * sqrt(c0)))) - 1._f)**2
-      
-      
+
+
       vf(k,i,j) = rmu(k) * re(k,i,j) / (rhoa_cgs * dmax)
     enddo      ! <i=1,NBIN>
   enddo      ! <k=1,NZ>
-  
+
   ! Return to caller with particle fall velocities evaluated.
   return
 end

--- a/setupvf_std.F90
+++ b/setupvf_std.F90
@@ -7,12 +7,12 @@
 !! indices correspond to vertical level <k>, bin index <i>, and aerosol
 !! group <j>.
 !!
-!! Method: first use Stokes flow (with Fuchs' size corrections, 
+!! Method: first use Stokes flow (with Fuchs' size corrections,
 !! valid only for Stokes flow) to estimate fall velocity, then calculate
 !! Reynolds' number (Re) (for spheres, Stokes drag coefficient is 24/Re).
 !! Then for Re > 1, correct drag coefficient (Cd) for turbulent boundary
-!! layer through standard trick to solving the drag problem: 
-!! fit y = log( Re ) as a function of x = log( Cd Re^2 ).  
+!! layer through standard trick to solving the drag problem:
+!! fit y = log( Re ) as a function of x = log( Cd Re^2 ).
 !! We use the data for rigid spheres taken from Figure 10-6 of
 !! Pruppacher and Klett (1978):
 !!
@@ -25,11 +25,11 @@
 !!
 !! Note that we ignore the "drag crisis" at Re > 200,000
 !! (as discussed on p. 341 and shown in Fig 10-36 of P&K 1978), where
-!! Cd drops dramatically to 0.2 for smooth, rigid spheres, and instead 
+!! Cd drops dramatically to 0.2 for smooth, rigid spheres, and instead
 !! assume Cd = 0.45 for Re > 1,000
 !!
 !! Note that we also ignore hydrodynamic deformation of liquid droplets
-!! as well as any breakup due to Rayleigh-Taylor instability.  
+!! as well as any breakup due to Rayleigh-Taylor instability.
 !!
 !! This routine requires that vertical profiles of temperature <t>,
 !! air density <rhoa>, and viscosity <rmu> are defined (i.e., initatm.f
@@ -44,10 +44,10 @@
 !! humidity according to the parameterizations of Gerber [1995] and
 !! Fitzgerald [1975]. The fall velocity is then based upon the wet radius
 !! rather than the dry radius. For particles that are not subject to
-!! swelling, the wet and dry radii are the same. 
+!! swelling, the wet and dry radii are the same.
 !!
 !! @author  Chuck Bardeen, Pete Colarco from Andy Ackerman
-!! @version Mar-2010 from Nov-2000 
+!! @version Mar-2010 from Nov-2000
 subroutine setupvf_std(carma, cstate, j, rc)
 
   ! types
@@ -69,7 +69,7 @@ subroutine setupvf_std(carma, cstate, j, rc)
   integer                 :: i, k
   real(kind=f)            :: x, y, cdrag
   real(kind=f)            :: rhoa_cgs, vg, rmfp, rkn, expon
-                                   
+
   ! Define formats
   1 format(/,'Non-spherical particles specified for group ',i3, &
       ' (ishape=',i3,') but spheres assumed in I_FALLRTN_STD.', &
@@ -79,12 +79,12 @@ subroutine setupvf_std(carma, cstate, j, rc)
   if( ishape(j) .ne. 1 )then
     if (do_print) write(LUNOPRT,1) j, ishape(j)
   endif
-  
+
   ! Loop over all atltitudes.
   do k = 1, NZ
 
     ! This is <rhoa> in cartesian coordinates (good old cgs units)
-    rhoa_cgs = rhoa(k) / (xmet(k)*ymet(k)*zmet(k))
+    rhoa_cgs = rhoa(k) / zmet(k)
 
     ! <vg> is mean thermal velocity of air molecules [cm/s]
     vg = sqrt(8._f / PI * R_AIR * t(k))
@@ -94,7 +94,7 @@ subroutine setupvf_std(carma, cstate, j, rc)
 
     ! Loop over particle size bins.
     do i = 1,NBIN
-    
+
       ! <rkn> is knudsen number
       rkn = rmfp / (r_wet(k,i,j) * rrat(i,j))
 
@@ -111,7 +111,7 @@ subroutine setupvf_std(carma, cstate, j, rc)
 
       if (re(k,i,j) .ge. 1._f) then
 
-        ! Correct drag coefficient for turbulence 
+        ! Correct drag coefficient for turbulence
         x = log(re(k,i,j) / bpm(k,i,j))
         y = x*(0.83_f - 0.013_f*x)
 
@@ -122,9 +122,9 @@ subroutine setupvf_std(carma, cstate, j, rc)
           ! drag coefficient from quadratic fit y(x) when Re < 1,000
           vf(k,i,j) = re(k,i,j) * rmu(k) / (2._f * r_wet(k,i,j) * rprat(i,j) * rhoa_cgs)
         else
-        
+
           ! drag coefficient = 0.45 independent of Reynolds number when Re > 1,000
-          cdrag = 0.45_f 
+          cdrag = 0.45_f
           vf(k,i,j) = bpm(k,i,j) * &
                       sqrt( 8._f * rhop_wet(k,i,j) * r_wet(k,i,j) * GRAV / &
                       (3._f * cdrag * rhoa_cgs * rprat(i,j)**2.) )

--- a/setupvf_std_shape.F90
+++ b/setupvf_std_shape.F90
@@ -9,9 +9,9 @@
 !!
 !!  Non-spherical particles are treated through shape factors <ishape>
 !!  and <eshape>.
-!!  
+!!
 !!  General method is to first use Stokes' flow to estimate fall
-!!!  velocity, then calculate reynolds' number, then use "y function" 
+!!!  velocity, then calculate reynolds' number, then use "y function"
 !!  (defined in Pruppacher and Klett) to reevaluate reynolds' number,
 !!  from which the fall velocity is finally obtained.
 !!
@@ -51,7 +51,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
 
 
   ! First evaluate factors that depend upon particle shape (used in correction
-  ! factor <bpm> below).  
+  ! factor <bpm> below).
   if (ishape(j) .eq. I_SPHERE) then
 
     ! Spheres
@@ -61,7 +61,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
   else if (ishape(j) .eq. I_HEXAGON) then
 
     ! Hexagons: taken from Turco et al (Planet. Space Sci. Rev. 30, 1147-1181, 1982)
-    ! with diffuse reflection of air molecules assumed 
+    ! with diffuse reflection of air molecules assumed
     f2 = (PI / 9._f / tan(PI / 6._f))**(ONE/3._f) * eshape(j)**(ONE/6._f)
 
   else if (ishape(j) .eq. I_CYLINDER)then
@@ -101,7 +101,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
   do k = 1,NZ
 
     ! This is <rhoa> in cartesian coordinates (good old cgs units)
-    rhoa_cgs = rhoa(k) / (xmet(k)*ymet(k)*zmet(k))
+    rhoa_cgs = rhoa(k) / zmet(k)
 
     ! <vg> is mean thermal velocity of air molecules [cm/s]
     vg = sqrt(8._f / PI * R_AIR * t(k))
@@ -135,7 +135,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
       expon = max(-POWMAX, expon)
       bpm(k,i,j) = 1._f + f1*f2*(1.246_f*rkn + 0.42_f*rkn*exp(expon))
 
-      ! These are first guesses for fall velocity and Reynolds' number, 
+      ! These are first guesses for fall velocity and Reynolds' number,
       ! valid for Reynolds' number < 0.01
       !
       ! This is "regime 1" in Pruppacher and Klett (chap. 10, pg 416).
@@ -149,7 +149,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
       if ((re(k,i,j) .ge. 0.01_f) .and. (re(k,i,j) .le. 300._f)) then
 
         ! This is "regime 2" in Pruppacher and Klett (chap. 10, pg 417).
-        ! 
+        !
         ! NOTE: This sphere case is not the same solution used when
         ! interpolating other shape factors. This seems potentially inconsistent.
         if (ishape(j) .eq. I_SPHERE) then
@@ -157,11 +157,11 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
           x = log(24._f * re(k,i,j) / bpm(k,i,j))
           y = -0.3318657e1_f + x * 0.992696_f - x**2 * 0.153193e-2_f - &
               x**3 * 0.987059e-3_f - x**4 * 0.578878e-3_f + &
-              x**5 * 0.855176E-04_f - x**6 * 0.327815E-05_f 
-              
+              x**5 * 0.855176E-04_f - x**6 * 0.327815E-05_f
+
           if (y .lt. -675._f) y = -675._f
           if (y .ge.  741._f) y =  741._f
-          
+
           re(k,i,j) = exp(y) * bpm(k,i,j)
 
         else if (eshape(j) .le. 1._f) then
@@ -174,7 +174,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
           endif
 
           if (eshape(j) .le. 0.2_f) then
-            
+
             ! P&K, page 424-427
             b0 = -1.33_f
             bb1 = 1.0217_f
@@ -191,7 +191,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
             bb2 = -0.049018_f + ex * (-0.047556_f + 0.049018_f)
             bb3 =               ex * (-0.002327_f)
           else
-          
+
             ! Extrapolating to cylinder cases on 436.
             ex = (eshape(j) - 0.5_f) / 0.5_f
             b0 = -1.3247_f    + ex * (-1.310_f    + 1.3247_f)
@@ -210,7 +210,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
           if (ishape(j) .eq. I_CYLINDER) then
             x = log10(8._f * rfix / PI)
           endif
-          
+
           ! P&K pg 430
           if( eshape(j) .le. 2._f )then
             ex = eshape(j) - 1._f
@@ -225,7 +225,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
             bb2 = -0.058810_f + ex * (-0.059312_f + 0.058810_f)
             bb3 = 0.002159_f  + ex * (0.0029941_f - 0.002159_f)
           else
-          
+
             ! This is interpolating to a solution for an infinite
             ! cylinder, so it may not be the greatest estimate.
             ex = 10._f / eshape(j)
@@ -234,7 +234,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
             bb2 = -0.030528_f + ex * (-0.059312_f + 0.030528_f)
             bb3 =               ex * (0.0029941_f)
           endif
-          
+
           y = b0 + x * bb1 + x**2 * bb2 + x**3 * bb3
           re(k,i,j) = 10._f**y * bpm(k,i,j)
 
@@ -253,13 +253,13 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
 !          if ((do_print) .and. (ishape(j) .ne. I_SPHERE)) write(LUNOPRT,*) "setupvfall:", j, i, k, re(k,i,j)
 !          rc = RC_ERROR
 !          return
-        
+
         z  = ((1.e6_f * rhoa_cgs**2) / (GRAV * rhop_wet(k,i,j) * rmu(k)**4))**(ONE/6._f)
         b0 = (24._f * vf(k,i,j) * rmu(k)) / 100._f
         x  = log(z * b0)
         y  = -5.00015_f + x * (5.23778_f   - x * (2.04914_f - x * (0.475294_f - &
                 x * (0.0542819_f - x * 0.00238449_f))))
-        
+
         if (y .lt. -675._f) y = -675.0_f
         if (y .ge.  741._f) y =  741.0_f
 
@@ -271,7 +271,7 @@ subroutine setupvf_std_shape(carma, cstate, j, rc)
         ! Figure 10-25 of Pruppacher and Klett, 1997)
         ilast = max(1,i-1)
         if ((vf(k,i,j) .lt.  vf(k,ilast,j)) .or. (re(k,i,j) .gt. 4000._f)) then
-          vf(k,i,j) = vf(k,ilast,j) 
+          vf(k,i,j) = vf(k,ilast,j)
         endif
       endif
     enddo    ! <i=1,NBIN>

--- a/sulfnucrate.F90
+++ b/sulfnucrate.F90
@@ -10,7 +10,7 @@
 !!
 !!  @author Mike Mills, Chuck Bardeen
 !!  @version Jun-2013
-subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry, rstar, nucbin, nucrate, rc) 
+subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry, rstar, nucbin, nucrate, rc)
   use carma_precision_mod
   use carma_enums_mod
   use carma_constants_mod
@@ -18,14 +18,14 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   use carmastate_mod
   use carma_mod
   use sulfate_utils
-  
+
   implicit none
-  
+
   type(carma_type), intent(in)         :: carma       !! the carma object
   type(carmastate_type), intent(inout) :: cstate      !! the carma state object
   integer, intent(in)                  :: iz          !! level index
   integer, intent(in)                  :: igroup      !! group index
-  real(kind=f), intent(out)            :: h2o         !! H2O concentrations in molec/cm3 
+  real(kind=f), intent(out)            :: h2o         !! H2O concentrations in molec/cm3
   real(kind=f), intent(out)            :: h2so4       !! H2SO4 concentrations in molec/cm3
   real(kind=f), intent(out)            :: beta1
   real(kind=f), intent(out)            :: beta2
@@ -35,8 +35,8 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   real(kind=f), intent(out)            :: nucrate     !! nucleation rate #/x/y/z/s
   integer, intent(inout)               :: rc          !! return code, negative indicates failure
 
-  !  Local declarations     
-  integer           :: i, ibin, ie    
+  !  Local declarations
+  integer           :: i, ibin, ie
   real(kind=f)      :: dens(46)
   real(kind=f)      :: pa(46)
   real(kind=f)      :: pb(46)
@@ -84,19 +84,19 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   real(kind=f)      :: exhom
   real(kind=f)      :: rmstar
   real(kind=f)      :: frac_h2so4
-  real(kind=f)      :: rhomlim  
+  real(kind=f)      :: rhomlim
   real(kind=f)      :: dnpot(46), dnwf(46)
   real(kind=f)      :: rho_H2SO4_wet
 
  5 format(/,'microfast::WARNING - nucleation rate exceeds 5.e1: ie=', i2,', iz=',i4,',lat=', &
-              f7.2,',lon=',f7.2, ', rhompe=', e10.3)	      
-  
+              f7.2,',lon=',f7.2, ', rhompe=', e10.3)
+
   rstar = -1._f
 
   !  Parameterized fit developed by Mike Mills in 1994 to the partial molal
   !  Gibbs energies (F2|o-F2) vs. weight percent H2SO4 table in Giauque et al.,
   !  J. Am. Chem. Soc, 82, 62-70, 1960.  The parameterization gives excellent
-  !  agreement.  Ayers (GRL, 7, 433-436, 1980) refers to F2|o-F2 as mu - mu_0 
+  !  agreement.  Ayers (GRL, 7, 433-436, 1980) refers to F2|o-F2 as mu - mu_0
   !  (chemical potential).  This parameterization may be replaced by a lookup
   !  table, as was done ultimately in the Garcia-Solomon sulfate code.
   do i = 1, 46
@@ -107,15 +107,15 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   ! Molecular weight ratio of H2SO4 / H2O:
   wtmolr = gwtmol(igash2so4) / gwtmol(igash2o)
 
-  ! Compute H2O and H2SO4 densities in g/cm3      
-  h2o_cgs   = gc(iz, igash2o)   / (zmet(iz) * xmet(iz) * ymet(iz))
-  h2so4_cgs = gc(iz, igash2so4) / (zmet(iz) * xmet(iz) * ymet(iz))
+  ! Compute H2O and H2SO4 densities in g/cm3
+  h2o_cgs   = gc(iz, igash2o)   / zmet(iz)
+  h2so4_cgs = gc(iz, igash2so4) / zmet(iz)
 
-  ! Compute H2O and H2SO4 concentrations in molec/cm3      
+  ! Compute H2O and H2SO4 concentrations in molec/cm3
   h2o   = h2o_cgs   * AVG / gwtmol(igash2o)
   h2so4 = h2so4_cgs * AVG / gwtmol(igash2so4)
 
-  ! Compute relative humidity of water wrt liquid water       
+  ! Compute relative humidity of water wrt liquid water
   rh = (supsatl(iz, igash2o) + 1._f) * 100._f
 
   ! Compute ln of H2O and H2SO4 ambient vapor pressures [dynes/cm2]
@@ -126,16 +126,16 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   do i = 1, 46
     dens(i) = dnc0(i) + dnc1(i) * t(iz)
 
-    ! Calc. water eq.vp over solution using (Lin & Tabazadeh eqn 5, JGR, 2001)  
+    ! Calc. water eq.vp over solution using (Lin & Tabazadeh eqn 5, JGR, 2001)
     cw = 22.7490_f + 0.0424817_f * dnwtp(i) - 0.0567432_f * dnwtp(i)**0.5_f - 0.000621533_f * dnwtp(i)**2
     dw = -5850.24_f + 21.9744_f * dnwtp(i) - 44.5210_f * dnwtp(i)**0.5_f - 0.384362_f * dnwtp(i)**2
-    
+
     ! pH20 | eq[mb]
     wvp   = exp(cw + dw / t(iz))
-    
+
     ! Ln(pH2O | eq [dynes/cm2])
     wvpln = log(wvp * 1013250._f / 1013.25_f)
-        
+
     ! Save the water eq.vp over solution at each wt pct into this array:
     !
     ! Ln(pH2O/pH2O|eq) with both terms in dynes/cm2
@@ -164,7 +164,7 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
 
     ! Convert atmospheres => dynes/cm2
     seqln = seqln + log(1013250._f)
-  
+
     ! Save the sulfuric acid eq.vp over solution at each wt pct into this array:
     !
     ! Ln(pH2SO4/pH2SO4|eq) with both terms in dynes/cm2
@@ -180,7 +180,7 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   dens1   = (dens(46) - dens(45)) / dw2
   fct(46) = c1(46) + c2(46) * 100._f * dens1 / dens(46)
   dens12 = dens1
-    
+
   do i = 45, 2, -1
     dw1    = dw2
     dens11 = dens12
@@ -193,17 +193,17 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
     ! Find saddle where fct(i)<0<fct(i+1)
     if (fct(i) * fct(i+1) <= 0._f) exit
   end do
-  
+
   if (i == 1) then
     dens1  = (dens(2) - dens(1)) / (dnwtp(2) - dnwtp(1))
     fct(1) = c1(1) + c2(1) * 100._f * dens1 / dens(1)
   end if
-      
+
   ! Possibility 1: loop finds no saddle, so no nucleation occurs:
   if (fct(i) * fct(i+1) > 0._f) then
-    nucbin  = 0 
+    nucbin  = 0
     nucrate = 0.0_f
-    
+
     return
 
   ! Possibility 2: loop crossed the saddle; interpolate to find exact value:
@@ -217,7 +217,7 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   ! Possibility 3: loop found the saddle point exactly
   else
     dstar = dens(i)
-  
+
     ! critical wtpct
     wstar = dnwtp(i)
     rhln  = pb(i)
@@ -232,32 +232,32 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
     rc = RC_ERROR
     return
   end if
-      
+
   ! Critical surface tension  [erg/cm2]
-  sigma = sulfate_surf_tens(carma, wstar, t(iz), rc)  
-      
+  sigma = sulfate_surf_tens(carma, wstar, t(iz), rc)
+
   ! Critical Y (eqn 13 in Zhao & Turco 1993) [erg/cm3]
   ystar = dstar * RGAS * t(iz) * (wfstar / gwtmol(igash2so4) &
       * raln + (1._f - wfstar) / gwtmol(igash2o) * rhln)
   if (ystar < 1.e-20_f) then
-    nucbin  = 0 
+    nucbin  = 0
     nucrate = 0.0_f
 
     return
   end if
 
-  ! Critical cluster radius [cm]        
-  rstar = 2._f * sigma / ystar 
+  ! Critical cluster radius [cm]
+  rstar = 2._f * sigma / ystar
   rstar = max(rstar, 0.0_f)
   r2    = rstar * rstar
 
   ! Critical Gibbs free energy [erg]
-  gstar = (4._f * PI / 3._f) * r2 * sigma 
- 
+  gstar = (4._f * PI / 3._f) * r2 * sigma
+
   !   kT/(2*Pi*M) = [erg/mol/K]*[K]/[g/mol] = [erg/g] = [cm2/s2]
   !   RB[erg/mol] = RGAS[erg/mol/K] * T[K] / (2Pi)
   rb = RGAS * t(iz) / 2._f / PI
-      
+
   ! Beta[cm/s] = sqrt(RB[erg/mol] / WTMOL[g/mol])
   beta1 = sqrt(rb / gwtmol(igash2so4)) ! H2SO4
   beta2 = sqrt(rb / gwtmol(igash2o))   ! H2O
@@ -269,7 +269,7 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   rpre = rpr * h2so4
 
   ! Zeldovitch non-equilibrium correction factor [unitless]
-  ! Jaecker-Voirol & Mirabel, 1988 (not considered in Zhao & Turco) 
+  ! Jaecker-Voirol & Mirabel, 1988 (not considered in Zhao & Turco)
   fracmol = 1._f /(1._f + wtmolr * (1._f - wfstar) / wfstar)
   zphi    = atan(fracmol)
   zeld    = 0.25_f / (sin(zphi))**2
@@ -289,7 +289,7 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   !   Calculate mass of critical nucleus
   rho_H2SO4_wet = sulfate_density(carma, wtpct(iz),t(iz), rc)
   rmstar = (4._f * PI / 3._f) * rho_H2SO4_wet * r2 * rstar
-     
+
   ! Calculate dry mass of critical nucleus
   rmstar = rmstar * wfstar
 
@@ -299,20 +299,19 @@ subroutine sulfnucrate(carma,cstate, iz, igroup, h2o, h2so4, beta1, beta2, ftry,
   else
     nucbin = 2 + int(log(rmstar / rmassup(1,igroup)) / log(rmrat(igroup)))
   endif
- 
+
   ! If none of the bins are large enough for the critical radius, then
   ! no nucleation will occur.
   if (nucbin > NBIN) then
-    nucbin  = 0 
+    nucbin  = 0
     nucrate = 0.0_f
   else
     ! Calculate the nucleation rate [#/cm3/s], Zhao & Turco eqn 16.
     nucrate = rpre * zeld * exhom
 
     ! Scale to #/x/y/z/s
-    nucrate = nucrate * zmet(iz) * xmet(iz) * ymet(iz)
+    nucrate = nucrate * zmet(iz)
   endif
-    
+
   return
 end subroutine sulfnucrate
-     

--- a/supersat.F90
+++ b/supersat.F90
@@ -35,7 +35,7 @@ subroutine supersat(carma, cstate, iz, igas, rc)
   ! Define gas constant for this gas
   rvap = RGAS / gwtmol(igas)
 
-  gc_cgs = gc(iz,igas) / (zmet(iz)*xmet(iz)*ymet(iz))
+  gc_cgs = gc(iz,igas) / zmet(iz)
 
   supsatl(iz,igas) = (gc_cgs * rvap * t(iz) - pvapl(iz,igas)) / pvapl(iz,igas)
   supsati(iz,igas) = (gc_cgs * rvap * t(iz) - pvapi(iz,igas)) / pvapi(iz,igas)
@@ -48,13 +48,13 @@ subroutine supersat(carma, cstate, iz, igas, rc)
   ! NOTE: This assumes that the cloud is an ice cloud.
   if (do_incloud) then
     alpha = rhcrit(iz) * (1._f - cldfrc(iz)) + cldfrc(iz)
-    
+
     supsatl(iz,igas) = (gc_cgs * rvap * t(iz) - alpha * pvapl(iz,igas)) / pvapl(iz,igas)
     supsati(iz,igas) = (gc_cgs * rvap * t(iz) - alpha * pvapi(iz,igas)) / pvapi(iz,igas)
-    
+
     ! Limit supersaturation to liquid saturation.
     supsatl(iz,igas) = min(supsatl(iz,igas), 0._f)
-    supsati(iz,igas) = min(supsati(iz,igas), (pvapl(iz,igas) - alpha * pvapi(iz,igas)) / pvapi(iz,igas))        
+    supsati(iz,igas) = min(supsati(iz,igas), (pvapl(iz,igas) - alpha * pvapi(iz,igas)) / pvapi(iz,igas))
   end if
 
   return
@@ -98,7 +98,7 @@ subroutine supersat_nocldf(carma, cstate, iz, igas, ssi, ssl, rc)
   ! Define gas constant for this gas
   rvap = RGAS / gwtmol(igas)
 
-  gc_cgs = gc(iz,igas) / (zmet(iz)*xmet(iz)*ymet(iz))
+  gc_cgs = gc(iz,igas) / zmet(iz)
 
   ssl = (gc_cgs * rvap * t(iz) - pvapl(iz,igas)) / pvapl(iz,igas)
   ssi = (gc_cgs * rvap * t(iz) - pvapi(iz,igas)) / pvapi(iz,igas)

--- a/tsolve.F90
+++ b/tsolve.F90
@@ -2,7 +2,7 @@
 ! reference the CARMA structure.
 #include "carma_globaer.h"
 
-!! This routine calculates new potential temperature concentration 
+!! This routine calculates new potential temperature concentration
 !! (and updates temperature) due to microphysical and radiative forcings.
 !! The equation solved (the first law of thermodynamics in flux form) is
 !!
@@ -40,20 +40,20 @@ subroutine tsolve(carma, cstate, iz, scale_threshold, rc)
   integer, intent(in)                  :: iz      !! z index
   real(kind=f)                         :: scale_threshold !! Scaling factor for convergence thresholds
   integer, intent(inout)               :: rc      !! return code, negative indicates failure
-  
-  1 format(/,'tsolve::ERROR - negative temperature for : iz=',i4,',lat=',&
-              f7.2,',lon=',f7.2,',T=',e10.3,',dT=',e10.3,',t_old=',e10.3,',d_gc=',e10.3,',dT_adv=',e10.3)
-  2 format(/,'tsolve::ERROR - temperature change to large for : iz=',i4,',lat=',&
-              f7.2,',lon=',f7.2,',T=',e10.3,',dT_rlh=',e10.3,',dT_pth=',e10.3,',t_old=',e10.3,',d_gc=',e10.3,',dT_adv=',e10.3)
-  3 format(/,'tsolve::ERROR - temperature change to large for : iz=',i4,',lat=',&
-              f7.2,',lon=',f7.2,',T=',e10.3,',dT_rlh=',e10.3,',dT_pth=',e10.3,',t_old=',e10.3)
-  4 format(/,'tsolve::ERROR - negative temperature for : iz=',i4,',lat=',&
-              f7.2,',lon=',f7.2,',T=',e10.3,',dT=',e10.3,',t_old=',e10.3)
-      
+
+  1 format(/,'tsolve::ERROR - negative temperature for : iz=',i4,',xc=',&
+              f7.2,',yc=',f7.2,',T=',e10.3,',dT=',e10.3,',t_old=',e10.3,',d_gc=',e10.3,',dT_adv=',e10.3)
+  2 format(/,'tsolve::ERROR - temperature change to large for : iz=',i4,',xc=',&
+              f7.2,',yc=',f7.2,',T=',e10.3,',dT_rlh=',e10.3,',dT_pth=',e10.3,',t_old=',e10.3,',d_gc=',e10.3,',dT_adv=',e10.3)
+  3 format(/,'tsolve::ERROR - temperature change to large for : iz=',i4,',xc=',&
+              f7.2,',yc=',f7.2,',T=',e10.3,',dT_rlh=',e10.3,',dT_pth=',e10.3,',t_old=',e10.3)
+  4 format(/,'tsolve::ERROR - negative temperature for : iz=',i4,',xc=',&
+              f7.2,',yc=',f7.2,',T=',e10.3,',dT=',e10.3,',t_old=',e10.3)
+
   real(kind=f)      :: dt           ! delta temperature
   real(kind=f)      :: threshold    ! convergence threshold
-  
-      
+
+
   ! Solve for the new <t> due to latent heat exchange and radiative heating.
   ! Latent and radiative heating rates are in units of [deg_K/s].
   !
@@ -63,8 +63,8 @@ subroutine tsolve(carma, cstate, iz, scale_threshold, rc)
   ! NOTE: Radiative heating by the particles is handled by the parent model, so
   ! that term does not need to be added here.
   dt         = dtime * rlprod
-  rlheat(iz) = rlheat(iz) + rlprod * dtime   
-  
+  rlheat(iz) = rlheat(iz) + rlprod * dtime
+
   ! With particle heating, you must also include the impact of heat
   ! conduction from the particle
   !
@@ -74,20 +74,20 @@ subroutine tsolve(carma, cstate, iz, scale_threshold, rc)
     dt           = dt + dtime * phprod
     partheat(iz) = partheat(iz) + phprod * dtime
   end if
-  
+
   t(iz) = t(iz) + dt
- 
-  
+
+
   ! Don't let the temperature go negative.
   if (t(iz) < 0._f) then
     if (do_substep) then
-      if (nretries == maxretries) then 
-        if (do_print) write(LUNOPRT,1) iz, lat, lon, t(iz), dt, told(iz), d_gc(iz, 1), d_t(iz)
+      if (nretries == maxretries) then
+        if (do_print) write(LUNOPRT,1) iz, xc, yc, t(iz), dt, told(iz), d_gc(iz, 1), d_t(iz)
       end if
     else
-      if (do_print) write(LUNOPRT,4) iz, lat, lon, t(iz), dt, told(iz)
+      if (do_print) write(LUNOPRT,4) iz, xc, yc, t(iz), dt, told(iz)
     end if
-    
+
     rc = RC_WARNING_RETRY
   end if
 
@@ -95,17 +95,17 @@ subroutine tsolve(carma, cstate, iz, scale_threshold, rc)
   ! to prevent overshooting that doesn't result in negative gas concentrations, but
   ! does result in excessive temperature swings.
   threshold = dt_threshold / scale_threshold
-  
+
   if (threshold /= 0._f) then
     if (abs(abs(dt)) > threshold) then
       if (do_substep) then
-        if (nretries == maxretries) then 
-          if (do_print) write(LUNOPRT,2) iz, lat, lon, t(iz), rlprod*dtime, dtime*partheat(iz), told(iz), d_gc(iz, 1), d_t(iz)
+        if (nretries == maxretries) then
+          if (do_print) write(LUNOPRT,2) iz, xc, yc, t(iz), rlprod*dtime, dtime*partheat(iz), told(iz), d_gc(iz, 1), d_t(iz)
         end if
       else
-        if (do_print) write(LUNOPRT,3) iz, lat, lon, t(iz), rlprod*dtime, dtime*partheat(iz), told(iz)
+        if (do_print) write(LUNOPRT,3) iz, xc, yc, t(iz), rlprod*dtime, dtime*partheat(iz), told(iz)
       end if
-  
+
       rc = RC_WARNING_RETRY
     end if
   end if

--- a/vaporp_h2so4_ayers1980.F90
+++ b/vaporp_h2so4_ayers1980.F90
@@ -6,7 +6,7 @@
 !!
 !!  <pvap_liq> and <pvap_ice> are vapor pressures in units of [dyne/cm^2]
 !!
-!!  Created   Dec-1995  (Ackerman) 
+!!  Created   Dec-1995  (Ackerman)
 !!  Modified  Sep-1997  (McKie)
 !!  Modified Jul-2001 (Mills)
 !!
@@ -24,7 +24,7 @@ subroutine vaporp_H2SO4_Ayers1980(carma, cstate, iz, rc, pvap_liq, pvap_ice)
   use carmastate_mod
   use carma_mod
   use sulfate_utils
-  
+
   implicit none
 
   type(carma_type), intent(in)         :: carma     !! the carma object
@@ -36,7 +36,7 @@ subroutine vaporp_H2SO4_Ayers1980(carma, cstate, iz, rc, pvap_liq, pvap_ice)
 
   ! Local declarations
   real(kind=f)            :: gc_cgs                          ! water vapor mass concentration [g/cm3]
-  real(kind=f)            :: fk1, fk4, fk4_1, fk4_2 
+  real(kind=f)            :: fk1, fk4, fk4_1, fk4_2
   real(kind=f)            :: factor_kulm                     ! Kulmala correction terms
   real(kind=f)            :: en, temp
   real(kind=f)            :: sulfeq
@@ -44,17 +44,17 @@ subroutine vaporp_H2SO4_Ayers1980(carma, cstate, iz, rc, pvap_liq, pvap_ice)
   real(kind=f), parameter :: t_crit_kulm = 905._f            !  Critical temperature = 1.5 * Boiling point
   real(kind=f), parameter :: fk0         = -10156._f / t0_kulm + 16.259_f   !  Log(Kulmala correction factor)
   real(kind=f), parameter :: fk2         = 1._f / t0_kulm
-  real(kind=f), parameter :: fk3         = 0.38_f / (t_crit_kulm - t0_kulm)    
-  
+  real(kind=f), parameter :: fk3         = 0.38_f / (t_crit_kulm - t0_kulm)
+
 
   ! Saturation vapor pressure of sulfuric acid
-  !  
+  !
   ! Don't allow saturation vapor pressure to underflow at very low temperatures
   temp=max(t(iz),140._f)
-  
+
   ! Convert water vapor concentration to g/cm3:
-  gc_cgs = gc(iz, igash2o) / (xmet(iz) * ymet(iz) * zmet(iz))
-  
+  gc_cgs = gc(iz, igash2o) / zmet(iz)
+
   ! Compute the sulfate composition based on Hanson parameterization
   ! to temperature and water vapor concentration.
   wtpct(iz) = wtpct_tabaz(carma, temp, gc_cgs, pvapl(iz, igash2o), rc)
@@ -62,7 +62,7 @@ subroutine vaporp_H2SO4_Ayers1980(carma, cstate, iz, rc, pvap_liq, pvap_ice)
   ! Parameterized fit to Giauque's (1959) enthalpies v. wt %:
   en = 4.184_f * (23624.8_f - 1.14208e8_f / ((wtpct(iz) - 105.318_f)**2 + 4798.69_f))
   en = max(en, 0.0_f)
- 
+
   ! Ayers' (1980) fit to sulfuric acid equilibrium vapor pressure:
   ! (Remember this is the log)
   ! SULFEQ=-10156/Temp+16.259-En/(8.3143*Temp)
@@ -76,16 +76,16 @@ subroutine vaporp_H2SO4_Ayers1980(carma, cstate, iz, rc, pvap_liq, pvap_ice)
 
   ! This is for pure H2SO4
   sulfeq = fk0 + 10156._f * factor_kulm
-           
+
   ! Adjust for WTPCT composition:
   sulfeq = sulfeq - en / (8.3143_f * temp)
-      
-  ! REMEMBER TO TAKE THE EXPONENTIAL!	
+
+  ! REMEMBER TO TAKE THE EXPONENTIAL!
   sulfeq = exp(sulfeq)
-  
+
   ! BUT this is in Atmospheres.  Convert ==> dynes/cm2
-  pvap_liq = sulfeq * 1.01325e6_f  
-  pvap_ice = sulfeq * 1.01325e6_f 
-  
+  pvap_liq = sulfeq * 1.01325e6_f
+  pvap_ice = sulfeq * 1.01325e6_f
+
   return
 end


### PR DESCRIPTION
This pull request includes:
 - removal of `igridh`, `xmet`, `ymet`, `dx`, `dy`, `xc`, `yc`
 - initialization of `igas` variables to zero
 - some code clean up

        modified:   calcrs.F90
        modified:   carma_globaer.h
        modified:   carma_types_mod.F90
        modified:   carmastate_mod.F90
        modified:   csolve.F90
        modified:   maxconc.F90
        modified:   nsubsteps.F90
        modified:   rhopart.F90
        modified:   setupatm.F90
        modified:   setupckern.F90
        modified:   setupgkern.F90
        modified:   setupgrow.F90
        modified:   setupvf_heymsfield2010.F90
        modified:   setupvf_std.F90
        modified:   setupvf_std_shape.F90
        modified:   sulfnucrate.F90
        modified:   supersat.F90
        modified:   vaporp_h2so4_ayers1980.F90
        modified:   vertical.F90